### PR TITLE
fix(known-hosts): dedup by host, save only post-handshake

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -86,9 +86,14 @@ export async function connect(
     process.env.PTY_RELAY_PASSPHRASE = passphrase;
   }
 
-  // Save this host for the interactive TUI (strip session from URL)
-  const baseUrl = createToken(parsed.host, parsed.publicKey, parsed.secret, undefined, parsed.clientToken ?? undefined);
-  await saveKnownHost(parsed.host, baseUrl, store);
+  // NOTE: known-host persistence used to fire here, before any network
+  // round-trip. That left bad entries on disk when the user pasted a
+  // typo'd token URL — and combined with the (now-fixed) full-URL dedup
+  // bug in saveKnownHost, those stale rows kept the original label and
+  // got resolved instead of newer, correct entries. We now persist only
+  // after the Noise NK handshake completes (see recordHostFromParsed
+  // calls from `onReady` in fetchSessions / attemptConnect), so we never
+  // record a host we haven't cryptographically confirmed.
 
   // If no session and no spawn, list sessions and re-exec with the chosen one
   if (!parsed.session && !options?.spawn) {
@@ -97,6 +102,31 @@ export async function connect(
   }
 
   attachSession(wsUrl, parsed, store, options);
+}
+
+/**
+ * Persist the host this `parsed` token points at. Composes a base URL
+ * (no session, current clientToken if any) and hands it to
+ * `saveKnownHost` — which dedups on host so re-saves overwrite in
+ * place. Fire-and-forget by design (matches the existing post-`approved`
+ * save behavior); errors are logged at the storage layer.
+ *
+ * Call ONLY after the Noise handshake completes. Pre-handshake saves
+ * persisted unverified URLs and were the source of the stale-entry
+ * class of bugs.
+ */
+export function recordHostFromParsed(
+  parsed: ReturnType<typeof parseToken>,
+  store: SecretStore
+): void {
+  const baseUrl = createToken(
+    parsed.host,
+    parsed.publicKey,
+    parsed.secret,
+    undefined,
+    parsed.clientToken ?? undefined,
+  );
+  saveKnownHost(parsed.host, baseUrl, store).catch(() => {});
 }
 
 function looksLikeTokenUrl(s: string): boolean {
@@ -168,6 +198,9 @@ function fetchSessions(
       daemonPublicKey: parsed.publicKey,
     }, {
       onReady: () => {
+        // Handshake done — daemon's pubkey verified by the NK pattern.
+        // Safe to persist the known-host entry now.
+        recordHostFromParsed(parsed, store);
         if (!process.env.PTY_RELAY_CLIENT_ANON) {
           connection.send(new TextEncoder().encode(JSON.stringify({
             type: "hello",
@@ -190,8 +223,7 @@ function fetchSessions(
               // Save the approved token for future reconnections AND
               // update parsed so the re-exec URL includes the token.
               parsed.clientToken = msg.client_token;
-              const newUrl = createToken(parsed.host, parsed.publicKey, parsed.secret, undefined, msg.client_token);
-              saveKnownHost(parsed.host, newUrl, store).catch(() => {});
+              recordHostFromParsed(parsed, store);
             } else if (msg.type === "error") {
               connection.close();
               reject(new Error(msg.message));
@@ -280,6 +312,10 @@ function attemptConnect(
       daemonPublicKey: parsed.publicKey,
     }, {
       onReady: () => {
+        // Handshake done — daemon's pubkey verified by the NK pattern.
+        // Safe to persist the known-host entry now. (See comment at the
+        // top of `connect` about why we don't save before this point.)
+        recordHostFromParsed(parsed, store);
         if (!process.env.PTY_RELAY_CLIENT_ANON) {
           connection.send(new TextEncoder().encode(JSON.stringify({
             type: "hello",
@@ -356,8 +392,8 @@ function attemptConnect(
             const msg = JSON.parse(new TextDecoder().decode(plaintext));
             if (msg.type === "approved" && msg.client_token) {
               // Save the approved token for future reconnections
-              const newUrl = createToken(parsed.host, parsed.publicKey, parsed.secret, undefined, msg.client_token);
-              saveKnownHost(parsed.host, newUrl, store).catch(() => {});
+              parsed.clientToken = msg.client_token;
+              recordHostFromParsed(parsed, store);
               return; // Don't pass to terminal
             }
           } catch {}
@@ -592,9 +628,11 @@ export async function connectEmbedded(
   const secretHash = computeSecretHash(parsed.secret);
   const wsUrl = getWebSocketUrl(parsed.host, "client", secretHash, undefined, parsed.clientToken ?? undefined);
 
-  // Save this host for the interactive TUI
-  const baseUrl = createToken(parsed.host, parsed.publicKey, parsed.secret, undefined, parsed.clientToken ?? undefined);
-  await saveKnownHost(parsed.host, baseUrl, options.store);
+  // Known-host persistence happens in attemptConnect's `onReady`
+  // callback below — after the Noise handshake confirms the daemon's
+  // identity. See the comment in `connect` for the bug class this
+  // closes (typo'd token URLs were ending up on disk before any
+  // network round-trip).
 
   const session = options.spawn || parsed.session!;
 

--- a/src/relay/known-hosts.test.ts
+++ b/src/relay/known-hosts.test.ts
@@ -55,8 +55,11 @@ describe("known-hosts", () => {
   });
 
   it("saves multiple hosts", async () => {
-    await saveKnownHost("mac-1", "https://relay.example.com#key1.secret1", store);
-    await saveKnownHost("mac-2", "https://relay.example.com#key2.secret2", store);
+    // Note: must be genuinely different hosts (different URL.host) —
+    // saveKnownHost dedups on host so two entries on the same origin
+    // collapse to one (the more recent key material wins).
+    await saveKnownHost("mac-1", "https://a.example.com#key1.secret1", store);
+    await saveKnownHost("mac-2", "https://b.example.com#key2.secret2", store);
     const hosts = await loadKnownHosts(store);
     expect(hosts).toHaveLength(2);
     expect(hosts[0].label).toBe("mac-1");
@@ -71,9 +74,30 @@ describe("known-hosts", () => {
     expect(hosts[0].label).toBe("new-name");
   });
 
+  it("collapses same-host re-saves to one entry even when key material rotates", async () => {
+    // Regression for the stale-fragment overwrite bug — see
+    // known-hosts.ts saveKnownHost comment. Same host, rotated
+    // `#pk.secret`, must yield ONE entry that keeps the original label
+    // and carries the new URL.
+    await saveKnownHost(
+      "home",
+      "https://relay.example.com#oldKey.oldSecret",
+      store
+    );
+    await saveKnownHost(
+      "home",
+      "https://relay.example.com#newKey.newSecret",
+      store
+    );
+    const hosts = await loadKnownHosts(store);
+    expect(hosts).toHaveLength(1);
+    expect(hosts[0].label).toBe("home");
+    expect(hosts[0].url).toBe("https://relay.example.com#newKey.newSecret");
+  });
+
   it("removes a host by label", async () => {
-    await saveKnownHost("mac-1", "https://relay.example.com#key1.secret1", store);
-    await saveKnownHost("mac-2", "https://relay.example.com#key2.secret2", store);
+    await saveKnownHost("mac-1", "https://a.example.com#key1.secret1", store);
+    await saveKnownHost("mac-2", "https://b.example.com#key2.secret2", store);
     await removeKnownHost("mac-1", store);
     const hosts = await loadKnownHosts(store);
     expect(hosts).toHaveLength(1);

--- a/src/relay/known-hosts.ts
+++ b/src/relay/known-hosts.ts
@@ -133,13 +133,24 @@ export function pickUniqueLabel(
   }
 }
 
+function urlHost(u: string): string | null {
+  try { return new URL(u).host; } catch { return null; }
+}
+
 /**
- * Save a self-hosted host. The URL is the unique key: repeated saves
- * of the same URL update the label in place. If the label collides
- * with a DIFFERENT host (different URL / different public-relay
- * entry), the new entry's label gets a URL-derived suffix so both
- * can coexist. This is a recent change — previously a label collision
- * silently evicted the older entry.
+ * Save a self-hosted host. The HOST (URL origin) is the unique key:
+ * repeated saves for the same host — even with a rotated `#pk.secret`
+ * fragment — update the entry in place. This matters when the remote
+ * daemon's state is wiped and it comes back up with fresh key material:
+ * connecting with the new token URL should overwrite the stale entry,
+ * not append a second one. If the label collides with a DIFFERENT host
+ * (different URL host / different public-relay entry), the new entry's
+ * label gets a URL-derived suffix so both can coexist.
+ *
+ * The old behavior dedup'd on the full URL including the fragment,
+ * which meant any pubkey/secret rotation left a stale entry alongside
+ * the new one — and worse, the stale entry kept the original label,
+ * so `connect <label>` would resolve to the stale row.
  */
 export async function saveKnownHost(
   label: string,
@@ -147,10 +158,17 @@ export async function saveKnownHost(
   store: SecretStore
 ): Promise<void> {
   const existing = await loadKnownHosts(store);
-  // Drop any prior entry for this URL (updating its label); keep
-  // entries with the SAME label but a different URL so we can resolve
-  // the collision below.
-  const kept = existing.filter((h) => h.url !== url);
+  const incomingHost = urlHost(url);
+  // Drop any prior self-hosted entry for the same host (this is the
+  // identity key — same daemon, possibly rotated key material). Keep
+  // public-relay entries (no url) and any entries whose stored url is
+  // malformed (defensive — we can't decide what host they belong to).
+  const kept = existing.filter((h) => {
+    if (h.url == null) return true;
+    const existingHost = urlHost(h.url);
+    if (existingHost == null) return true;
+    return existingHost !== incomingHost;
+  });
   const usedLabels = new Set(kept.map((h) => h.label));
   const finalLabel = pickUniqueLabel(label, url, usedLabels);
   kept.push({ label: finalLabel, url });

--- a/test/connect-host-record.test.ts
+++ b/test/connect-host-record.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import sodium from "libsodium-wrappers-sumo";
+import { ready, generateKeypair, generateSecret, createToken, parseToken } from "../src/crypto/index.ts";
+import { recordHostFromParsed } from "../src/commands/connect.ts";
+import { loadKnownHosts } from "../src/relay/known-hosts.ts";
+import type { SecretName, SecretStore } from "../src/storage/secret-store.ts";
+
+/**
+ * Q2 regression tests — known-host entries must only be persisted after
+ * the Noise handshake has cryptographically confirmed the daemon's
+ * identity. Pre-fix, `connect()` and `connectEmbedded()` saved the host
+ * up-front, before any network round-trip; pasting a typo'd token URL
+ * polluted the store.
+ *
+ * Two halves:
+ *  1. `recordHostFromParsed` (the helper now gated on `onReady`) records
+ *     the entry correctly when called.
+ *  2. Structural invariant: every direct `saveKnownHost(` call site in
+ *     `src/commands/connect.ts` lives inside `recordHostFromParsed` —
+ *     there is no path that saves before the handshake. This is a file-
+ *     content assertion rather than a runtime drive of the whole
+ *     connect/reconnect loop because that loop is harder to terminate
+ *     cleanly from a unit test (interruptible sleeps, no external
+ *     cancel hook). If a future change reintroduces an eager save, this
+ *     test fails immediately and points at the file.
+ */
+
+class MemStore implements SecretStore {
+  readonly backend = "passphrase" as const;
+  private data = new Map<SecretName, Uint8Array>();
+  async load(n: SecretName) { return this.data.get(n) ?? null; }
+  async save(n: SecretName, p: Uint8Array) { this.data.set(n, p); }
+  async delete(n: SecretName) { this.data.delete(n); }
+}
+
+describe("recordHostFromParsed", () => {
+  it("saves the parsed host with the canonical base URL (no session segment)", async () => {
+    await ready();
+    const store = new MemStore();
+    const { publicKey } = generateKeypair();
+    const secret = generateSecret();
+    const tokenUrl = createToken("home.local:8099", publicKey, secret, "some-session");
+    const parsed = parseToken(tokenUrl);
+
+    recordHostFromParsed(parsed, store);
+    // The helper is fire-and-forget (.catch on the inner save). Yield
+    // a microtask so the save promise lands.
+    await new Promise((r) => setImmediate(r));
+
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(1);
+    expect(hosts[0].label).toBe("home.local:8099");
+    // The persisted URL strips the session and preserves the parsed
+    // clientToken (none in this case).
+    const persisted = hosts[0].url!;
+    expect(persisted).not.toContain("/some-session");
+    const reparsed = parseToken(persisted);
+    expect(reparsed.host).toBe("home.local:8099");
+    expect(sodium.to_base64(reparsed.publicKey, sodium.base64_variants.URLSAFE_NO_PADDING))
+      .toBe(sodium.to_base64(publicKey, sodium.base64_variants.URLSAFE_NO_PADDING));
+  });
+
+  it("overwrites the prior entry for the same host (composes with Q1 host-dedup)", async () => {
+    await ready();
+    const store = new MemStore();
+    const oldKey = generateKeypair();
+    const newKey = generateKeypair();
+    const oldUrl = createToken("home.local:8099", oldKey.publicKey, generateSecret());
+    const newUrl = createToken("home.local:8099", newKey.publicKey, generateSecret());
+
+    recordHostFromParsed(parseToken(oldUrl), store);
+    await new Promise((r) => setImmediate(r));
+    recordHostFromParsed(parseToken(newUrl), store);
+    await new Promise((r) => setImmediate(r));
+
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(1);
+    expect(hosts[0].label).toBe("home.local:8099");
+    expect(hosts[0].url).toBe(newUrl);
+  });
+});
+
+describe("connect.ts save-only-on-success invariant", () => {
+  it("the only direct `saveKnownHost(` call site lives inside recordHostFromParsed", () => {
+    // Read the connect.ts source. Every `saveKnownHost(` substring must
+    // be either (a) the import, (b) inside a comment, or (c) inside the
+    // body of `recordHostFromParsed`. If a new eager save reappears,
+    // this test pins the regression.
+    const src = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src/commands/connect.ts"),
+      "utf8"
+    );
+
+    const lines = src.split("\n");
+    // Find the body of recordHostFromParsed — from its declaration to
+    // the matching closing brace.
+    const declIdx = lines.findIndex((l) => l.includes("export function recordHostFromParsed"));
+    expect(declIdx).toBeGreaterThan(-1);
+    let depth = 0;
+    let bodyEnd = -1;
+    let started = false;
+    for (let i = declIdx; i < lines.length; i++) {
+      for (const ch of lines[i]) {
+        if (ch === "{") { depth++; started = true; }
+        else if (ch === "}") {
+          depth--;
+          if (started && depth === 0) { bodyEnd = i; break; }
+        }
+      }
+      if (bodyEnd !== -1) break;
+    }
+    expect(bodyEnd).toBeGreaterThan(declIdx);
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Strip an inline `//` comment so a commented-out save doesn't
+      // trip the assertion.
+      const slashIdx = line.indexOf("//");
+      const codePart = slashIdx === -1 ? line : line.slice(0, slashIdx);
+      if (!codePart.includes("saveKnownHost(")) continue;
+
+      // Allowed: the import line.
+      if (codePart.match(/import\s*\{\s*[^}]*saveKnownHost/)) continue;
+      // Allowed: inside recordHostFromParsed body.
+      if (i >= declIdx && i <= bodyEnd) continue;
+
+      throw new Error(
+        `Unexpected direct \`saveKnownHost(\` call site at connect.ts:${i + 1}: ` +
+          `${line.trim()}\nAll persistence must go through recordHostFromParsed, ` +
+          `which is gated on the post-handshake \`onReady\` callback.`
+      );
+    }
+  });
+
+  it("`saveKnownHost(` is not reachable from the `connect()` entry path before WS open", () => {
+    // Stricter slice: lines from the top of `export async function connect`
+    // up to (but not including) the `attachSession(` tail. If any direct
+    // saveKnownHost or recordHostFromParsed call slips in here, an
+    // eager pre-handshake save snuck back in.
+    const src = fs.readFileSync(
+      path.join(import.meta.dirname, "..", "src/commands/connect.ts"),
+      "utf8"
+    );
+    const lines = src.split("\n");
+    const fnStart = lines.findIndex((l) => l.match(/^export async function connect\(/));
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = lines.findIndex((l, i) => i > fnStart && l.match(/^\}/));
+    expect(fnEnd).toBeGreaterThan(fnStart);
+
+    for (let i = fnStart; i < fnEnd; i++) {
+      const line = lines[i];
+      const slashIdx = line.indexOf("//");
+      const codePart = slashIdx === -1 ? line : line.slice(0, slashIdx);
+      expect(codePart.includes("saveKnownHost(")).toBe(false);
+      expect(codePart.includes("recordHostFromParsed(")).toBe(false);
+    }
+  });
+});

--- a/test/known-hosts-public.test.ts
+++ b/test/known-hosts-public.test.ts
@@ -163,6 +163,58 @@ describe("label-collision avoidance on save", () => {
     expect(hosts[0].label).toBe("second-name");
   });
 
+  it("saveKnownHost overwrites in place when the same host arrives with rotated key material (regression: known-hosts-host-dedup)", async () => {
+    // Scenario: remote host's state was wiped, daemon came back up with
+    // fresh #pk.secret. User runs `connect <new-token-url>`. We must
+    // overwrite the stale entry — not append a second one that the old
+    // label still resolves to. Pre-fix this filtered on the full URL
+    // (including fragment) so the dedup missed, and the stale row kept
+    // the original label while the new one got a URL-suffixed label.
+    const store = new MemStore();
+    await saveKnownHost("home", "http://a.example/#oldPk.oldSecret", store);
+    await saveKnownHost("home", "http://a.example/#newPk.newSecret", store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(1);
+    expect(hosts[0].label).toBe("home");
+    expect(hosts[0].url).toBe("http://a.example/#newPk.newSecret");
+  });
+
+  it("saveKnownHost overwrites in place even when only the secret rotates", async () => {
+    // Same pubkey, new secret — still the same daemon, dedup must hit.
+    const store = new MemStore();
+    await saveKnownHost("home", "http://a.example/#pk.s1", store);
+    await saveKnownHost("home", "http://a.example/#pk.s2", store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(1);
+    expect(hosts[0].url).toBe("http://a.example/#pk.s2");
+  });
+
+  it("saveKnownHost host-dedup ignores port-equal-but-host-different (different machines are different entries)", async () => {
+    // a.example:8099 and b.example:8099 share a port but are different
+    // daemons — they must NOT collapse into one entry. URL.host includes
+    // the port + hostname, so the dedup naturally keeps them separate.
+    const store = new MemStore();
+    await saveKnownHost("alice", "http://a.example:8099/#k.s", store);
+    await saveKnownHost("bob", "http://b.example:8099/#k.s", store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(2);
+  });
+
+  it("saveKnownHost host-dedup leaves public-relay entries untouched", async () => {
+    // Public-relay entries have no `url` field. The self-hosted save
+    // must not interpret them as "stale self-hosted" and evict them.
+    const store = new MemStore();
+    await savePublicKnownHost(
+      { label: "remote", relayUrl: "http://relay", publicKey: "pk1" },
+      store
+    );
+    await saveKnownHost("local", "http://localhost:8099/#k.s", store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(2);
+    expect(hosts.some((h) => h.label === "remote" && isPublicHost(h))).toBe(true);
+    expect(hosts.some((h) => h.label === "local" && h.url === "http://localhost:8099/#k.s")).toBe(true);
+  });
+
   it("savePublicKnownHost re-save of the same pubkey updates the label in place", async () => {
     const store = new MemStore();
     await savePublicKnownHost(


### PR DESCRIPTION
## Summary

Two bugs surfaced when a remote daemon's state was wiped and it came back up with fresh `#pk.secret` — myobie hit this on another laptop and the only working recovery was `rm`'ing the state dir. This PR closes both so the class of bug can't recur.

### Q1 — the load-bearing fix

`saveKnownHost` in `src/relay/known-hosts.ts` dedup'd the existing array on `h.url !== url` — full-URL match including the fragment. Walkthrough:

1. Daemon X comes up with key material A. Client connects → store records `{label:"X", url:"https://X/#A"}`.
2. Daemon X's state is wiped; daemon X restarts with key material B.
3. Client runs `connect https://X/#B`. The filter `h.url !== url` is **true** (different fragments) → stale row kept. `usedLabels` contains `"X"` → `pickUniqueLabel` returns `"X-https"`. End state: two rows. Stale one keeps the original `"X"` label.
4. `connect X` later → resolves to the stale row → handshake fails.

Fix: dedup on `new URL(h.url).host` instead. Same host = same daemon, rotated `#pk.secret` is just key rotation. Picked **idea-1** from the diagnosis (filter on URL.host) over **idea-2** (add a `host` field with load-time migration): URL stays the only source of truth, no derived state to drift, no migration. Defensive try/catch around `new URL()` handles malformed entries.

Public-relay entries (`h.url == null`) are explicitly passed through — `savePublicKnownHost` already dedups correctly on `(relayUrl, publicKey)` and is untouched.

### Q2 — defensive cleanup

`connect()` (`src/commands/connect.ts:91`) and `connectEmbedded()` (`:597`) used to save the host **before** any network round-trip. A typo'd token URL would land on disk; combined with Q1, those stale rows kept the original label and were resolved instead of newer, correct entries.

Saves now happen only inside `onReady` (post-Noise-NK handshake) via a new `recordHostFromParsed` helper. We never persist a host we haven't cryptographically confirmed.

**Trade-off**: the affordance of "host shows in `pty-relay ls` before first connect succeeds" goes away. Per myobie's call: pollution beats convenience. Comment at the top of `connect()` documents the rationale so a future change doesn't accidentally reintroduce the eager save.

## Tests

- `src/relay/known-hosts.test.ts`: two pre-existing tests ("saves multiple hosts", "removes a host by label") were using the same origin with different fragments — they were pinning the Q1 bug. Updated to use genuinely different hosts. Added a regression test that saves the same host twice with rotated key material and asserts ONE entry survives with the original label and the new URL.
- `test/known-hosts-public.test.ts`: four new cases — rotated `pk+secret`, rotated secret only, host-with-port disambiguation, and public-relay entries surviving a self-hosted save.
- `test/connect-host-record.test.ts` (new): exercises `recordHostFromParsed` directly + a structural assertion that the only direct `saveKnownHost(` call site in `connect.ts` lives inside the helper. If a future change reintroduces an eager save, CI fails immediately at this test with a pointer to the file.

## Verification

- `npx tsc --noEmit` clean
- `npm test` 533 passed
- `npm run build:browser` clean
- Live cycle: not yet — integration tests under `integration/e2e.test.ts:833` ("connect saves the host to known-hosts file") still wait for `$` (post-handshake) and pass conceptually with the new save timing.

## Test plan

- [ ] `npm test` clean on main after merge
- [ ] Reproduce the original failure scenario on a real laptop: connect to a daemon, wipe daemon state, restart with new key material, `connect <new-token-url>` — verify the stale row is overwritten in place (not appended).
- [ ] Sanity: paste a typo'd token URL into `connect`, abort, run `pty-relay ls` — verify nothing landed on disk.