### PR TITLE
chore: track .mcp.json with the canonical "st" MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "st": {
+      "type": "stdio",
+      "command": "/Volumes/SSD/src/github.com/myobie/coord/bin/st",
+      "args": [
+        "mcp",
+        "--channel"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
brief-005-phase4 of the coord → smalltalk/st rename, mirroring pty's reference PR #46.

## Summary

- MCP server name `coord` → `st`.
- Binary path `bin/coord` → `bin/st` (the canonical entry — both still work via Phase 0 aliases, but `bin/st` is what we settle on).
- The on-disk `/Volumes/SSD/.../coord/` path stays — Phase 2's directory symlink keeps it portable.

Companion local-only edits (gitignored, apply on each clone):
- `pty.toml`: `COORD_IDENTITY` → `ST_IDENTITY`, `server:coord` → `server:st`.
- `.claude/settings.local.json`: `"coord"` → `"st"` in `enabledMcpjsonServers`.

Calling tools as `coord_*` continues to work via the Phase 0 alias mode until Phase 5 cleanup.

## Test plan

- [ ] Restart pty session → MCP server registers as `st`.
- [ ] No more `[smalltalk] honoring COORD_IDENTITY` stderr warning on shell-outs.
- [ ] `coord_*` tool calls continue to work via alias mode.

cos merges per the standing no-autopush rule.