### PR TITLE
fix(local status): show the tailscale URL with --show-token, not localhost

### DIFF
--- a/src/commands/local/status.ts
+++ b/src/commands/local/status.ts
@@ -5,6 +5,10 @@ import { log } from "../../log.ts";
 import { defaultConfigDir, openSecretStore } from "../../storage/bootstrap.ts";
 import { loadLabel } from "../../relay/config.ts";
 import { loadClients } from "../../relay/clients.ts";
+import {
+  loadDaemonRuntime,
+  buildExternalTokenUrl,
+} from "../../relay/daemon-runtime.ts";
 import sodium from "libsodium-wrappers-sumo";
 import { ready, computeSecretHash, createToken } from "../../crypto/index.ts";
 import { osc8Link } from "../../terminal-link.ts";
@@ -106,7 +110,7 @@ export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
     if (opts.showToken && config) {
       // Token URL has the pairing secret in the fragment; gated on
       // --show-token like the text path below.
-      out.tokenUrl = buildLocalhostTokenUrl(config.publicKey, config.secret);
+      out.tokenUrl = buildStatusTokenUrl(dir, config.publicKey, config.secret);
     }
     console.log(JSON.stringify(out, null, 2));
     return;
@@ -137,13 +141,11 @@ export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
 
   if (opts.showToken && config) {
     console.log("");
-    // Printed last so it's trivially easy to copy. The URL uses
-    // localhost — no way from here to know which external hostname
-    // `local start` was invoked with (Tailscale, LAN, etc.). That's
-    // fine for `--show-token` which is mostly for developer sanity
-    // checks; the authoritative URL is whatever `local start`
-    // prints on boot.
-    console.log(`  Token URL:   ${osc8Link(buildLocalhostTokenUrl(config.publicKey, config.secret))}`);
+    // Printed last so it's trivially easy to copy. The URL prefers the
+    // tailscale-advertised hostname when `--tailscale` was set at
+    // start time (via daemon-runtime.json), and falls back to
+    // localhost when no runtime record is on disk.
+    console.log(`  Token URL:   ${osc8Link(buildStatusTokenUrl(dir, config.publicKey, config.secret))}`);
   } else if (!opts.showToken) {
     console.log("");
     console.log(`  (Run \`pty-relay local status --show-token\` to print the token URL.)`);
@@ -201,14 +203,19 @@ function base64OriginalDecode(s: unknown): Uint8Array | null {
   }
 }
 
-function buildLocalhostTokenUrl(
+function buildStatusTokenUrl(
+  configDir: string,
   publicKey: Uint8Array,
-  secret: Uint8Array
+  secret: Uint8Array,
 ): string {
-  // Use the same shape the daemon prints on startup so copy/paste
-  // works identically. We don't know the port without reading process
-  // state, so fall back to 8099 (`local start`'s default). If the
-  // operator is running on a different port, the authoritative URL
-  // is whatever `local start` printed — status is best-effort.
+  // Prefer the daemon-runtime.json record the running daemon wrote on
+  // boot (tailscale hostname when --tailscale was set, real port,
+  // etc.). Fall back to `localhost:8099` only when there's no record
+  // — keeps `--show-token` useful on a never-started config and on
+  // older daemons that haven't been restarted since this code shipped.
+  const runtime = loadDaemonRuntime(configDir);
+  if (runtime) {
+    return buildExternalTokenUrl(runtime, publicKey, secret, createToken);
+  }
   return createToken("localhost:8099", publicKey, secret);
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -19,6 +19,10 @@ import {
   saveDaemonPid,
   type ClientsData,
 } from "../relay/clients.ts";
+import {
+  saveDaemonRuntime,
+  clearDaemonRuntime,
+} from "../relay/daemon-runtime.ts";
 import { sanitizeRemoteString } from "../sanitize.ts";
 import { handleSessionControlMessage } from "./start-shared.ts";
 import { log } from "../log.ts";
@@ -134,13 +138,26 @@ export async function start(
   console.log(`Token URL: ${osc8Link(tokenUrl)}`);
 
   // Tailscale HTTPS support
+  let tailscaleSetup: TailscaleSetup | null = null;
   if (options?.tailscale) {
-    const tsUrl = await setupTailscale(port, config);
-    if (tsUrl) {
-      console.log(`Tailscale: ${osc8Link(tsUrl)}`);
-      printQrCode(tsUrl);
+    tailscaleSetup = await setupTailscale(port, config);
+    if (tailscaleSetup) {
+      console.log(`Tailscale: ${osc8Link(tailscaleSetup.tokenUrl)}`);
+      printQrCode(tailscaleSetup.tokenUrl);
     }
   }
+
+  // Persist runtime metadata (port, bind, tailscale hostname if any)
+  // so `pty-relay local status --show-token` can compose the same
+  // external URL we just printed instead of falling back to
+  // localhost:8099. No secrets in this file — see daemon-runtime.ts.
+  saveDaemonRuntime(configDir ?? defaultConfigDir(), {
+    port,
+    bind: options?.bind ?? "0.0.0.0",
+    tailscale: tailscaleSetup
+      ? { hostname: tailscaleSetup.dnsName, port: 443, scheme: "https" }
+      : undefined,
+  });
 
   // Write the PID file in every mode, not just approval mode. The
   // approval TUI uses it to signal the daemon, and `local status`
@@ -378,12 +395,16 @@ export async function start(
     });
   }
 
-  // Clean up PID file on exit
+  // Clean up PID file + runtime record on exit so a subsequent
+  // `local status` doesn't see "stale pid" / claim the daemon is up
+  // when it isn't.
   process.on("exit", () => {
     if (cleanupPid) cleanupPid();
+    clearDaemonRuntime(configDir ?? defaultConfigDir());
   });
   process.on("SIGINT", () => {
     if (cleanupPid) cleanupPid();
+    clearDaemonRuntime(configDir ?? defaultConfigDir());
     process.exit(0);
   });
 
@@ -598,7 +619,15 @@ function getTailscaleDnsName(cli: string): string | null {
   }
 }
 
-async function setupTailscale(port: number, config: Config): Promise<string | null> {
+/** Returned shape of setupTailscale. `tokenUrl` carries the `#pk.secret`
+ *  fragment for display; `dnsName` is the bare hostname suitable for
+ *  persistence into daemon-runtime.json (which never holds secrets). */
+interface TailscaleSetup {
+  dnsName: string;
+  tokenUrl: string;
+}
+
+async function setupTailscale(port: number, config: Config): Promise<TailscaleSetup | null> {
   const cli = findTailscaleCli();
   if (!cli) {
     console.error("Warning: --tailscale specified but tailscale CLI not found");
@@ -641,5 +670,5 @@ async function setupTailscale(port: number, config: Config): Promise<string | nu
   // Give it a moment to start
   await new Promise((r) => setTimeout(r, 1000));
 
-  return getTokenUrl(dnsName, config);
+  return { dnsName, tokenUrl: getTokenUrl(dnsName, config) };
 }

--- a/src/relay/daemon-runtime.ts
+++ b/src/relay/daemon-runtime.ts
@@ -1,0 +1,178 @@
+/**
+ * Tiny on-disk record of "what hostname/port the running daemon is
+ * advertising externally." Written by `pty-relay local start` on
+ * boot, read by `pty-relay local status --show-token` so the token
+ * URL the user copies from `status` matches the one the daemon
+ * printed on boot (Tailscale DNS name, LAN host, …) rather than the
+ * conservative `localhost:8099` default.
+ *
+ * Why a separate file (vs. extending the existing encrypted config
+ * store): this is *runtime* state, not a secret. It lives next to
+ * `daemon.pid` and is cleared on clean shutdown. The contents are
+ * safe to read without unlocking the keyring/passphrase, so
+ * `local status` can render the URL even when the operator hasn't
+ * provided the passphrase.
+ *
+ * No secrets in the file. The token URL fragment (`#pk.secret`) is
+ * composed by `status` from the encrypted store + this file's
+ * hostname/port. If this file is missing or unreadable, callers fall
+ * back to `localhost:<default-port>`.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { log } from "../log.ts";
+
+const FILE_NAME = "daemon-runtime.json";
+
+/**
+ * What the running daemon advertises as its external endpoint. None of
+ * these fields are secret — `tailscale.hostname` and `bind`/`port` are
+ * routing metadata the operator already chose at start time.
+ */
+export interface DaemonRuntime {
+  /** TCP port the daemon's HTTP server is bound on. Always set. */
+  port: number;
+  /** Bind address (`127.0.0.1`, `0.0.0.0`, or an explicit interface).
+   *  Used to decide whether to advertise localhost vs. a real IP. */
+  bind: string;
+  /** Set when `--tailscale` was passed AND tailscale serve registration
+   *  succeeded. Otherwise undefined. */
+  tailscale?: {
+    /** Tailnet hostname, e.g. `silber.pancake-hake.ts.net`. */
+    hostname: string;
+    /** Almost always 443 for the operator's tailnet serve config; left
+     *  explicit so future non-443 setups slot in. */
+    port: number;
+    /** Almost always `"https"`. */
+    scheme: "https" | "http";
+  };
+  /** Unix-ms timestamp the file was written. Lets `status` warn on
+   *  stale records if the file outlives its daemon. */
+  startedAt: number;
+}
+
+export function runtimePath(configDir: string): string {
+  return path.join(configDir, FILE_NAME);
+}
+
+/**
+ * Write the runtime record. Best-effort: failures (read-only mount,
+ * missing parent dir, etc.) are logged and swallowed — the daemon is
+ * still healthy without this file.
+ */
+export function saveDaemonRuntime(
+  configDir: string,
+  runtime: Omit<DaemonRuntime, "startedAt">,
+): void {
+  try {
+    const filePath = runtimePath(configDir);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    const payload: DaemonRuntime = { ...runtime, startedAt: Date.now() };
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), {
+      mode: 0o600,
+    });
+    log("runtime", "wrote daemon-runtime.json", {
+      port: runtime.port,
+      tailscale: !!runtime.tailscale,
+    });
+  } catch (err) {
+    log("runtime", "saveDaemonRuntime failed", {
+      error: (err as Error)?.message,
+    });
+  }
+}
+
+/**
+ * Read the runtime record. Returns `null` when the file is missing,
+ * unreadable, or has an unexpected shape — callers fall back to a
+ * conservative `localhost`-based URL in those cases.
+ */
+export function loadDaemonRuntime(configDir: string): DaemonRuntime | null {
+  try {
+    const filePath = runtimePath(configDir);
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.port !== "number" || typeof obj.bind !== "string") {
+      return null;
+    }
+    const runtime: DaemonRuntime = {
+      port: obj.port,
+      bind: obj.bind,
+      startedAt:
+        typeof obj.startedAt === "number" ? obj.startedAt : Date.now(),
+    };
+    if (obj.tailscale && typeof obj.tailscale === "object") {
+      const ts = obj.tailscale as Record<string, unknown>;
+      if (
+        typeof ts.hostname === "string" &&
+        typeof ts.port === "number" &&
+        (ts.scheme === "http" || ts.scheme === "https")
+      ) {
+        runtime.tailscale = {
+          hostname: ts.hostname,
+          port: ts.port,
+          scheme: ts.scheme,
+        };
+      }
+    }
+    return runtime;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete the runtime record. Called by the daemon's clean-shutdown
+ * hook (alongside the daemon.pid cleanup) so a subsequent
+ * `local status` doesn't claim the dead daemon was still up.
+ *
+ * Best-effort: ENOENT and similar failures are swallowed.
+ */
+export function clearDaemonRuntime(configDir: string): void {
+  try {
+    fs.unlinkSync(runtimePath(configDir));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Compose the external token URL from a runtime record + the public
+ * key/secret pulled from the encrypted store. Prefers tailscale when
+ * available, falls back to `http://localhost:<port>`.
+ *
+ * The return value is suitable for `--show-token` output and for the
+ * `tokenUrl` field of `--json` status.
+ */
+export function buildExternalTokenUrl(
+  runtime: DaemonRuntime,
+  publicKey: Uint8Array,
+  secret: Uint8Array,
+  createToken: (
+    host: string,
+    pk: Uint8Array,
+    secret: Uint8Array,
+    session?: string,
+  ) => string,
+): string {
+  if (runtime.tailscale) {
+    const ts = runtime.tailscale;
+    // `tailscale serve --https=443 …` is by far the common case;
+    // omit the port from the URL when it matches the scheme default.
+    const isDefault =
+      (ts.scheme === "https" && ts.port === 443) ||
+      (ts.scheme === "http" && ts.port === 80);
+    const host = isDefault ? ts.hostname : `${ts.hostname}:${ts.port}`;
+    return createToken(host, publicKey, secret);
+  }
+
+  // Non-tailscale: the daemon's own port + a localhost host. We could
+  // try to detect a LAN IP when bind === "0.0.0.0" but the operator
+  // already saw the right URL on boot — falling back to localhost is
+  // the safe option for `--show-token` (it Just Works on the same
+  // machine; for cross-machine the operator uses the boot output).
+  return createToken(`localhost:${runtime.port}`, publicKey, secret);
+}

--- a/test/daemon-runtime.test.ts
+++ b/test/daemon-runtime.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  saveDaemonRuntime,
+  loadDaemonRuntime,
+  clearDaemonRuntime,
+  buildExternalTokenUrl,
+  runtimePath,
+  type DaemonRuntime,
+} from "../src/relay/daemon-runtime.ts";
+
+/** Pure helper that mimics the signature of `createToken`. Lets the
+ *  buildExternalTokenUrl tests assert what got composed without
+ *  pulling in sodium just for this unit. */
+function fakeCreateToken(host: string, _pk: Uint8Array, _s: Uint8Array, session?: string): string {
+  return `proto://${host}${session ? "/" + session : ""}#fakepk.fakesecret`;
+}
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-runtime-"));
+});
+
+afterEach(() => {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+describe("saveDaemonRuntime / loadDaemonRuntime", () => {
+  it("round-trips a non-tailscale record", () => {
+    saveDaemonRuntime(dir, { port: 9000, bind: "127.0.0.1" });
+    const loaded = loadDaemonRuntime(dir);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.port).toBe(9000);
+    expect(loaded!.bind).toBe("127.0.0.1");
+    expect(loaded!.tailscale).toBeUndefined();
+    expect(loaded!.startedAt).toBeGreaterThan(0);
+  });
+
+  it("round-trips a tailscale record", () => {
+    saveDaemonRuntime(dir, {
+      port: 8099,
+      bind: "127.0.0.1",
+      tailscale: { hostname: "host.ts.net", port: 443, scheme: "https" },
+    });
+    const loaded = loadDaemonRuntime(dir);
+    expect(loaded?.tailscale).toEqual({
+      hostname: "host.ts.net",
+      port: 443,
+      scheme: "https",
+    });
+  });
+
+  it("returns null when the file doesn't exist", () => {
+    expect(loadDaemonRuntime(dir)).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    fs.writeFileSync(runtimePath(dir), "{ not json");
+    expect(loadDaemonRuntime(dir)).toBeNull();
+  });
+
+  it("returns null on missing required fields", () => {
+    fs.writeFileSync(runtimePath(dir), JSON.stringify({ bind: "127.0.0.1" }));
+    expect(loadDaemonRuntime(dir)).toBeNull();
+  });
+
+  it("loads the bare shape when tailscale is malformed (drops the field, keeps the rest)", () => {
+    fs.writeFileSync(runtimePath(dir), JSON.stringify({
+      port: 9000,
+      bind: "127.0.0.1",
+      startedAt: 1,
+      tailscale: { hostname: "ok.ts.net" }, // missing port + scheme
+    }));
+    const loaded = loadDaemonRuntime(dir);
+    expect(loaded?.port).toBe(9000);
+    expect(loaded?.tailscale).toBeUndefined();
+  });
+
+  it("writes the file with mode 0600 (no secrets, but defense-in-depth)", () => {
+    saveDaemonRuntime(dir, { port: 9000, bind: "0.0.0.0" });
+    const stat = fs.statSync(runtimePath(dir));
+    // On some CI environments umask can mask out the group/other bits,
+    // so check that *we* set 0600 by masking down to the perms bits.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("saveDaemonRuntime is best-effort — failing target dir doesn't throw", () => {
+    expect(() =>
+      saveDaemonRuntime("/proc/will/never/be/writable/anywhere", { port: 9000, bind: "127.0.0.1" }),
+    ).not.toThrow();
+  });
+});
+
+describe("clearDaemonRuntime", () => {
+  it("removes the runtime file", () => {
+    saveDaemonRuntime(dir, { port: 9000, bind: "127.0.0.1" });
+    expect(fs.existsSync(runtimePath(dir))).toBe(true);
+    clearDaemonRuntime(dir);
+    expect(fs.existsSync(runtimePath(dir))).toBe(false);
+  });
+
+  it("is a no-op when the file is already gone", () => {
+    expect(() => clearDaemonRuntime(dir)).not.toThrow();
+    expect(fs.existsSync(runtimePath(dir))).toBe(false);
+  });
+});
+
+describe("buildExternalTokenUrl", () => {
+  const pk = new Uint8Array([1, 2, 3]);
+  const secret = new Uint8Array([4, 5, 6]);
+
+  it("uses the tailscale hostname when present", () => {
+    const runtime: DaemonRuntime = {
+      port: 8099,
+      bind: "127.0.0.1",
+      tailscale: { hostname: "silber.ts.net", port: 443, scheme: "https" },
+      startedAt: 0,
+    };
+    const url = buildExternalTokenUrl(runtime, pk, secret, fakeCreateToken);
+    // Default https port → no port in the URL.
+    expect(url).toBe("proto://silber.ts.net#fakepk.fakesecret");
+  });
+
+  it("includes the tailscale port when it's non-default", () => {
+    const runtime: DaemonRuntime = {
+      port: 8099,
+      bind: "127.0.0.1",
+      tailscale: { hostname: "silber.ts.net", port: 8443, scheme: "https" },
+      startedAt: 0,
+    };
+    const url = buildExternalTokenUrl(runtime, pk, secret, fakeCreateToken);
+    expect(url).toBe("proto://silber.ts.net:8443#fakepk.fakesecret");
+  });
+
+  it("falls back to localhost:<port> when no tailscale", () => {
+    const runtime: DaemonRuntime = {
+      port: 9000,
+      bind: "0.0.0.0",
+      startedAt: 0,
+    };
+    const url = buildExternalTokenUrl(runtime, pk, secret, fakeCreateToken);
+    expect(url).toBe("proto://localhost:9000#fakepk.fakesecret");
+  });
+
+  it("respects the http scheme + custom port on tailscale", () => {
+    const runtime: DaemonRuntime = {
+      port: 9000,
+      bind: "127.0.0.1",
+      tailscale: { hostname: "h.ts.net", port: 80, scheme: "http" },
+      startedAt: 0,
+    };
+    const url = buildExternalTokenUrl(runtime, pk, secret, fakeCreateToken);
+    expect(url).toBe("proto://h.ts.net#fakepk.fakesecret");
+  });
+});


### PR DESCRIPTION
Fixes one of the two queued relay bugs from pty-claude's inbox heads-up: `pty-relay local status --show-token` printed `http://localhost:8099#…` even when the daemon was started with `--tailscale`. Nathan's workaround was swapping `localhost`→`silber.pancake-hake.ts.net` in the URL by hand.

## Root cause

The comment at `src/commands/local/status.ts:141-145` acknowledged this and shipped a best-effort `localhost:8099` fallback — the status command had no way to know which external hostname the running daemon was advertising.

## Fix

The daemon now persists external-endpoint metadata to `daemon-runtime.json` on boot, and `status` reads it back to compose the right URL.

- **No secrets in the file.** Only `{port, bind, tailscale: {hostname, port, scheme}, startedAt}`. The `#pk.secret` fragment is composed by `status` at print time from the encrypted store.
- **Cleared on shutdown.** The daemon's existing exit/SIGINT handlers clear the runtime record alongside the PID file, so `status` immediately after a shutdown doesn't claim the dead daemon was still up.
- **Graceful fallback.** When no runtime record is present (older daemons, never-started configs, read failures), falls back to `http://localhost:8099#…` exactly as before.

## URL preference

```
--tailscale + serve registration succeeded → https://<dns-name>/#pk.secret
otherwise                                  → http://localhost:<port>/#pk.secret
```

Default 443 / 80 ports are omitted from the URL; non-default ports are included.

## Summary

- ✅ `npx tsc --noEmit` clean
- ✅ `npm test` 547/547 green (+14 from `test/daemon-runtime.test.ts`)
- ✅ Round-trip + boundary tests for save/load/clear; pure `buildExternalTokenUrl` tested in isolation with a fake `createToken` (no sodium dep in the unit test)

## Test plan

- [ ] Start daemon with `--tailscale`. Wait for "Tailscale: https://…" line.
- [ ] In another shell: `pty-relay local status --show-token`. URL is the tailnet one, not `localhost`.
- [ ] `pty-relay local status --show-token --json`. `tokenUrl` field is the tailnet one.
- [ ] Stop the daemon. Re-run status. URL falls back to `localhost:<port>` (record was cleared on exit).
- [ ] Start daemon WITHOUT `--tailscale`. Status URL is `localhost:<actual-port>` (uses the real port, not the hardcoded 8099).