### PR TITLE
fix(local status): probe TCP port liveness in addition to daemon.pid

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1037,12 +1037,19 @@ async function dispatchLocal(): Promise<void> {
   if (subcommand === "status") {
     const configDir = getFlag("--config-dir") ?? undefined;
     const passphraseFile = getFlag("--passphrase-file") ?? undefined;
+    const portArg = getFlag("--port");
+    const port = portArg ? parseInt(portArg, 10) : undefined;
+    if (portArg && !Number.isFinite(port)) {
+      console.error(`Invalid --port value: ${portArg}`);
+      process.exit(1);
+    }
     const { localStatusCommand } = await import("./commands/local/status.ts");
     await localStatusCommand({
       json: hasFlag("--json"),
       showToken: hasFlag("--show-token"),
       configDir,
       passphraseFile,
+      port,
     });
     return;
   }
@@ -1084,6 +1091,11 @@ Subcommands:
                                    approved-client count. Prints the
                                    token URL only with --show-token
                                    (fragment contains auth material).
+  status --port <N>               Probe the given port for daemon
+                                   liveness (default: 8099). Reports
+                                   "running on port N" even when the
+                                   pid file is stale (supervisor-
+                                   respawned daemons).
   reset [--force]                 Wipe just self-hosted daemon state
                                    (config, clients, daemon.pid).
                                    Preserves public-relay enrollment

--- a/src/commands/local/status.ts
+++ b/src/commands/local/status.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import * as net from "node:net";
 import { log } from "../../log.ts";
 import { defaultConfigDir, openSecretStore } from "../../storage/bootstrap.ts";
 import { loadLabel } from "../../relay/config.ts";
@@ -27,7 +28,16 @@ export interface LocalStatusOpts {
   showToken?: boolean;
   configDir?: string;
   passphraseFile?: string;
+  /** TCP port to probe when checking daemon liveness. Defaults to
+   *  8099 (the documented `local start` default). Override when the
+   *  operator started the daemon on a non-default port — `status`
+   *  doesn't otherwise know which port was passed. */
+  port?: number;
 }
+
+/** Default port used by `pty-relay local start` and probed by `status`
+ *  when no port is supplied. Kept in sync with `cli.ts`'s usage text. */
+const DEFAULT_RELAY_PORT = 8099;
 
 export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
   await ready();
@@ -85,7 +95,8 @@ export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
   }
 
   const label = (await loadLabel(store)) || os.hostname();
-  const daemonInfo = probeDaemon(dir);
+  const probePort = opts.port ?? DEFAULT_RELAY_PORT;
+  const daemonInfo = await probeDaemon(dir, probePort);
   const clientStats = await loadClientStats(store);
   const pubKeyB64 = config
     ? sodium.to_base64(config.publicKey, sodium.base64_variants.URLSAFE_NO_PADDING)
@@ -126,8 +137,16 @@ export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
   }
   if (daemonInfo.running) {
     console.log(`  Daemon:      running (pid ${daemonInfo.pid})`);
+  } else if (daemonInfo.portListening) {
+    // The PID file is stale or absent BUT something is listening on
+    // the relay port. Common cause: the daemon was respawned by a
+    // supervisor (`pty up`, systemd, etc.) without re-running
+    // `pty-relay local start`, OR the previous daemon died hard before
+    // cleanup. The pid we have (if any) is no longer authoritative.
+    const staleNote = daemonInfo.pid !== null ? ` (recorded pid ${daemonInfo.pid} is stale)` : "";
+    console.log(`  Daemon:      running on port ${probePort}${staleNote}`);
   } else if (daemonInfo.pid !== null) {
-    console.log(`  Daemon:      stale pid ${daemonInfo.pid} (process not found)`);
+    console.log(`  Daemon:      stale pid ${daemonInfo.pid} (process not found, port ${probePort} not listening)`);
   } else {
     console.log(`  Daemon:      not running`);
   }
@@ -151,25 +170,87 @@ export async function localStatusCommand(opts: LocalStatusOpts): Promise<void> {
 }
 
 interface DaemonProbe {
+  /** PID read from `daemon.pid`, if the file exists and parses. */
   pid: number | null;
+  /** True iff `process.kill(pid, 0)` succeeded — the pid points at a
+   *  live process. Not authoritative on its own: a supervisor may have
+   *  respawned the daemon after a hard crash without rewriting the
+   *  pid file, leaving the file stale even though the daemon is up. */
   running: boolean;
+  /** True iff a TCP connect to the relay port succeeded — something is
+   *  bound there. Use this in combination with `running` to decide
+   *  the real liveness state. (`running` true + `portListening` true
+   *  = normal. `portListening` true + `running` false = supervised
+   *  respawn / stale pid. Both false = down.) */
+  portListening: boolean;
 }
 
-function probeDaemon(configDir: string): DaemonProbe {
+export async function probeDaemon(configDir: string, port: number): Promise<DaemonProbe> {
+  const pid = readDaemonPid(configDir);
+  const running = pid !== null && isProcessAlive(pid);
+  const portListening = await isPortListening("127.0.0.1", port);
+  return { pid, running, portListening };
+}
+
+function readDaemonPid(configDir: string): number | null {
   const pidPath = path.join(configDir, "daemon.pid");
-  if (!fs.existsSync(pidPath)) return { pid: null, running: false };
+  if (!fs.existsSync(pidPath)) return null;
   try {
-    const pid = parseInt(fs.readFileSync(pidPath, "utf-8").trim(), 10);
-    if (!isFinite(pid)) return { pid: null, running: false };
-    try {
-      process.kill(pid, 0);
-      return { pid, running: true };
-    } catch {
-      return { pid, running: false };
-    }
+    const raw = fs.readFileSync(pidPath, "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    return isFinite(pid) ? pid : null;
   } catch {
-    return { pid: null, running: false };
+    return null;
   }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort TCP listen probe. Connects to `host:port` with a tight
+ * timeout. Returns true iff the connection completes — anything
+ * else (refused, no route, timeout, DNS fail) is treated as "no one
+ * listening." We don't try to speak the relay protocol; the goal is
+ * just "is something bound here that LOOKS like our daemon."
+ *
+ * Loopback only — we don't probe external interfaces because we
+ * have no idea what's running on the operator's network.
+ */
+function isPortListening(host: string, port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const settle = (v: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(v);
+    };
+    try {
+      const socket = new net.Socket();
+      const timeout = setTimeout(() => {
+        try { socket.destroy(); } catch {}
+        settle(false);
+      }, 500);
+      socket.once("connect", () => {
+        clearTimeout(timeout);
+        try { socket.end(); } catch {}
+        settle(true);
+      });
+      socket.once("error", () => {
+        clearTimeout(timeout);
+        settle(false);
+      });
+      socket.connect(port, host);
+    } catch {
+      settle(false);
+    }
+  });
 }
 
 interface ClientStats {

--- a/test/local-status-probe.test.ts
+++ b/test/local-status-probe.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import * as net from "node:net";
+import { probeDaemon } from "../src/commands/local/status.ts";
+
+/**
+ * Unit tests for `probeDaemon`'s dual-signal (PID alive + TCP port
+ * listening). The full CLI shape of `pty-relay local status` is
+ * exercised by the integration suite; here we just pin the probe's
+ * logic since it's the load-bearing fix for Nathan's "stale pid
+ * 12839 (process not found)" reading-it-wrong bug.
+ */
+
+let dir: string;
+let listenServer: net.Server | null = null;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "local-status-probe-"));
+});
+
+afterEach(async () => {
+  if (listenServer) {
+    await new Promise<void>((r) => listenServer!.close(() => r()));
+    listenServer = null;
+  }
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+/** Bind a TCP server on a free port. Returns the port. */
+async function bindLoopback(): Promise<number> {
+  listenServer = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    listenServer!.once("error", reject);
+    listenServer!.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = listenServer!.address();
+  if (!addr || typeof addr === "string") throw new Error("no address");
+  return addr.port;
+}
+
+/** Pick an unused port — bind, read the port, then close. */
+async function pickUnusedPort(): Promise<number> {
+  const tmp = net.createServer();
+  await new Promise<void>((r) => tmp.listen(0, "127.0.0.1", () => r()));
+  const addr = tmp.address();
+  if (!addr || typeof addr === "string") throw new Error("no address");
+  const port = addr.port;
+  await new Promise<void>((r) => tmp.close(() => r()));
+  return port;
+}
+
+describe("probeDaemon", () => {
+  it("running:true, portListening:true when the pid is alive AND the port is bound", async () => {
+    const port = await bindLoopback();
+    fs.writeFileSync(path.join(dir, "daemon.pid"), String(process.pid));
+    const probe = await probeDaemon(dir, port);
+    expect(probe).toEqual({
+      pid: process.pid,
+      running: true,
+      portListening: true,
+    });
+  });
+
+  it("running:false, portListening:true on a stale pid file with the port still bound (supervisor respawn case)", async () => {
+    const port = await bindLoopback();
+    // Pid 2**30 - 1 ≈ 1 billion — high enough that it's never a real
+    // process on any sane system.
+    const stalePid = 2 ** 30 - 1;
+    fs.writeFileSync(path.join(dir, "daemon.pid"), String(stalePid));
+    const probe = await probeDaemon(dir, port);
+    expect(probe.pid).toBe(stalePid);
+    expect(probe.running).toBe(false);
+    expect(probe.portListening).toBe(true);
+  });
+
+  it("running:false, portListening:false when nothing's around (Nathan's clean-shutdown case)", async () => {
+    const port = await pickUnusedPort();
+    const probe = await probeDaemon(dir, port);
+    expect(probe).toEqual({
+      pid: null,
+      running: false,
+      portListening: false,
+    });
+  });
+
+  it("pid file present but port not bound — surfaces as pid:N, running:?, portListening:false", async () => {
+    const port = await pickUnusedPort();
+    fs.writeFileSync(path.join(dir, "daemon.pid"), String(process.pid));
+    const probe = await probeDaemon(dir, port);
+    expect(probe.pid).toBe(process.pid);
+    expect(probe.running).toBe(true); // this process IS alive
+    expect(probe.portListening).toBe(false);
+  });
+
+  it("missing daemon.pid + port bound — running:false, portListening:true (this is the daemon-up-but-no-pid-file case)", async () => {
+    const port = await bindLoopback();
+    const probe = await probeDaemon(dir, port);
+    expect(probe.pid).toBeNull();
+    expect(probe.running).toBe(false);
+    expect(probe.portListening).toBe(true);
+  });
+
+  it("garbage daemon.pid (non-numeric) — same as missing", async () => {
+    const port = await pickUnusedPort();
+    fs.writeFileSync(path.join(dir, "daemon.pid"), "not a number");
+    const probe = await probeDaemon(dir, port);
+    expect(probe.pid).toBeNull();
+    expect(probe.running).toBe(false);
+    expect(probe.portListening).toBe(false);
+  });
+
+  it("the TCP probe times out fast (under ~1s) when the port is firewalled / unreachable", async () => {
+    // 0.0.0.0:1 is reserved + typically firewalled. Connecting to it
+    // either errors immediately or times out — our 500ms cap means
+    // this resolves quickly either way. We don't assert a specific
+    // result (depends on platform), just that it doesn't hang.
+    const start = Date.now();
+    const probe = await probeDaemon(dir, 1);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1500);
+    expect(typeof probe.portListening).toBe("boolean");
+  });
+});


### PR DESCRIPTION
Fixes the second queued relay bug from pty-claude's inbox heads-up: `pty-relay local status` reports "stale pid 12839 (process not found)" even when a daemon IS up. Nathan hit this on his daily machine.

## Root cause

The PID file alone isn't a reliable liveness signal in supervised setups. When a hard-crashed daemon is respawned by `pty up` (or systemd, etc.) without re-running `pty-relay local start`, the PID file keeps the dead PID and `status` trusts it.

## Fix

`probeDaemon` now returns a third signal — `portListening`, populated by a 500ms TCP connect probe to `127.0.0.1:<port>`. The status output combines both signals:

| PID file       | Port listening | Status text                                                   |
|----------------|----------------|---------------------------------------------------------------|
| alive          | yes            | `running (pid X)` (unchanged)                                 |
| dead/absent    | yes            | `running on port N (recorded pid X is stale)` — daemon IS up  |
| dead           | no             | `stale pid X (process not found, port N not listening)`       |
| missing        | no             | `not running` (unchanged)                                     |

## CLI surface

- `--port <N>` overrides the probed port (default 8099). Lets the operator probe a non-default port without restarting the daemon.
- `--json` output now includes `daemon.portListening` alongside `daemon.pid` / `daemon.running`. Downstream tooling can branch on the dual signal too.

The TCP probe is loopback-only (127.0.0.1) — we don't probe external interfaces. Connect timeout is hard-capped at 500ms so a firewalled port doesn't hang `status`.

## Composability with PR #19

PR #19 (`fix/show-token-tailscale-url`) introduces `daemon-runtime.json` which records the real port the daemon bound. When that lands too, status can read the port from there instead of relying on the `--port` flag — a follow-up PR will close that loop. This PR works standalone on `main` today.

## Verification

- `npx tsc --noEmit` clean
- `npm test` 540/540 green (+7 from `test/local-status-probe.test.ts`)
- Test coverage: every combination of PID-alive × port-bound, garbage PID file, missing daemon.pid, fast-timeout check on a firewalled port. `probeDaemon` is exported to make it directly unit-testable.

## Test plan

- [ ] Stop daemon. `pty-relay local status` → "not running."
- [ ] Start daemon. `pty-relay local status` → "running (pid X)."
- [ ] Manually edit `~/.local/state/pty/relay/daemon.pid` to a dead PID. `pty-relay local status` → "running on port 8099 (recorded pid X is stale)."
- [ ] Delete `daemon.pid` entirely. `pty-relay local status` → same "running on port 8099" with no stale-pid note.
- [ ] Stop daemon. `pty-relay local status --port 9999` → "stale pid X (process not found, port 9999 not listening)."