### PR TITLE
feat(ssh): brief-010 phase 1 — ssh:// peers, ls + add subcommands

### DIFF
--- a/integration/ssh-ls.test.ts
+++ b/integration/ssh-ls.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { spawnSync } from "node:child_process";
+import {
+  CLI_ENTRY,
+  createTestContext,
+  destroyTestContext,
+  integEnv,
+  type TestContext,
+} from "./helpers/index.ts";
+import { openSecretStore } from "../src/storage/bootstrap.ts";
+import { saveSshKnownHost } from "../src/relay/known-hosts.ts";
+
+/**
+ * Brief-010 phase 1: end-to-end check that `pty-relay ls <label>`
+ * with an ssh:// host shells out to `ssh <userHost> pty list --json`
+ * and renders the result alongside relay-hosted entries.
+ *
+ * We don't depend on a real local sshd. Instead we drop a fake `ssh`
+ * script earlier on PATH that records its arguments + emits the
+ * `pty list --json` shape we'd expect from a real peer. That tests
+ * everything from CLI dispatch → host-resolve → transport-ssh.ts →
+ * ls.ts rendering without the real sshd / host-key / firewall mess.
+ */
+
+let ctx: TestContext;
+let fakeSshDir: string;
+
+beforeAll(() => {
+  ctx = createTestContext();
+  fakeSshDir = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-ls-fake-"));
+
+  // The fake `ssh` script accepts the same positional + -o args ssh
+  // would, looks at argv to decide what to emit, and writes a marker
+  // to a log file so the test can assert call shape. Bash because
+  // it's universal on macOS + Linux CI.
+  const fakeSshPath = path.join(fakeSshDir, "ssh");
+  fs.writeFileSync(fakeSshPath, `#!/usr/bin/env bash
+echo "$@" >> "${fakeSshDir}/calls.log"
+# The last two args are <userHost> <remote-command-tokens...>
+# We respond to "pty --version" and "pty list --json" specifically.
+last_cmd="$*"
+case "$last_cmd" in
+  *"pty --version"*)
+    echo "1.2.3-fake"
+    exit 0
+    ;;
+  *"pty list --json"*)
+    cat <<'JSON'
+[
+  {
+    "name": "fake-session-1",
+    "status": "running",
+    "command": "bash",
+    "tags": {}
+  },
+  {
+    "name": "fake-session-2",
+    "status": "running",
+    "command": "/usr/bin/htop",
+    "tags": {"role":"monitor"}
+  }
+]
+JSON
+    exit 0
+    ;;
+esac
+echo "fake ssh: unrecognized command" >&2
+exit 1
+`);
+  fs.chmodSync(fakeSshPath, 0o755);
+});
+
+afterAll(async () => {
+  await destroyTestContext(ctx);
+  try { fs.rmSync(fakeSshDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("ssh:// transport — pty-relay ls", () => {
+  it("ls renders ssh peer sessions returned by `pty list --json`", async () => {
+    const configDir = path.join(ctx.stateDir, "ssh-ls-relay");
+    fs.mkdirSync(configDir, { recursive: true });
+
+    // Seed a known-host entry. The label is what we'll resolve via the
+    // CLI; the sshUrl is what gets shell-outed.
+    const { store } = await openSecretStore(configDir, {
+      interactive: false,
+      passphraseFile: undefined,
+    });
+    await saveSshKnownHost(
+      { label: "fakebox", sshUrl: "ssh://me@fakebox" },
+      store,
+    );
+
+    const result = spawnSync(
+      "node",
+      [CLI_ENTRY, "ls", "--config-dir", configDir, "--json"],
+      {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          ...integEnv({ PTY_SESSION_DIR: ctx.stateDir }),
+          // Prepend the fake-ssh directory to PATH so our script wins
+          // over the real ssh.
+          PATH: `${fakeSshDir}:${process.env.PATH ?? ""}`,
+        },
+        timeout: 15_000,
+      },
+    );
+    if (result.status !== 0) {
+      console.log("ls stderr:", result.stderr);
+      console.log("ls stdout:", result.stdout);
+    }
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as Array<{
+      label: string;
+      url: string;
+      sessions: Array<{ name: string; command: string; tags?: Record<string, string> }>;
+      error: string | null;
+    }>;
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].label).toBe("fakebox");
+    expect(parsed[0].url).toBe("ssh://me@fakebox");
+    expect(parsed[0].error).toBeNull();
+    expect(parsed[0].sessions.map((s) => s.name)).toEqual([
+      "fake-session-1",
+      "fake-session-2",
+    ]);
+    expect(parsed[0].sessions[1].tags).toEqual({ role: "monitor" });
+
+    // Assert the fake ssh was called with the right shape.
+    const calls = fs.readFileSync(path.join(fakeSshDir, "calls.log"), "utf-8");
+    expect(calls).toContain("me@fakebox pty list --json");
+    // BatchMode=yes is the headless-friendly default.
+    expect(calls).toContain("-o BatchMode=yes");
+  }, 30_000);
+
+  it("`pty-relay add ssh://…` probes via `pty --version` before saving", async () => {
+    const configDir = path.join(ctx.stateDir, "ssh-add-relay");
+    fs.mkdirSync(configDir, { recursive: true });
+
+    // Clear the call log to keep this case isolated.
+    fs.writeFileSync(path.join(fakeSshDir, "calls.log"), "");
+
+    const result = spawnSync(
+      "node",
+      [
+        CLI_ENTRY,
+        "add",
+        "ssh://nathan@beta",
+        "--label",
+        "beta",
+        "--config-dir",
+        configDir,
+      ],
+      {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          ...integEnv({ PTY_SESSION_DIR: ctx.stateDir }),
+          PATH: `${fakeSshDir}:${process.env.PATH ?? ""}`,
+        },
+        timeout: 15_000,
+      },
+    );
+    if (result.status !== 0) {
+      console.log("add stderr:", result.stderr);
+      console.log("add stdout:", result.stdout);
+    }
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Added beta → ssh://nathan@beta");
+    expect(result.stdout).toContain("ok (pty 1.2.3-fake)");
+
+    // The probe used `pty --version`, not `pty list --json`.
+    const calls = fs.readFileSync(path.join(fakeSshDir, "calls.log"), "utf-8");
+    expect(calls).toContain("nathan@beta pty --version");
+
+    // Now reading back via ls should see the new entry. We need the
+    // fake to keep responding to `list --json` for the second
+    // invocation, which it does.
+    const ls = spawnSync(
+      "node",
+      [CLI_ENTRY, "ls", "--config-dir", configDir, "--json"],
+      {
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          ...integEnv({ PTY_SESSION_DIR: ctx.stateDir }),
+          PATH: `${fakeSshDir}:${process.env.PATH ?? ""}`,
+        },
+        timeout: 15_000,
+      },
+    );
+    expect(ls.status).toBe(0);
+    const parsed = JSON.parse(ls.stdout);
+    expect(parsed[0].label).toBe("beta");
+    expect(parsed[0].url).toBe("ssh://nathan@beta");
+  }, 30_000);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,11 @@ Commands:
   events --json <host>                         Emit JSONL for scripting
   rename <old> <new>        Rename a saved known-host entry
   forget <host-label>       Remove a saved host
+  add ssh://[user@]host[:port] [--label <name>]
+                            Add an ssh-reachable peer to known-hosts.
+                            Probes with ssh BatchMode=yes + pty
+                            --version before saving so unreachable
+                            peers don't get recorded.
   connect [token-url]       Connect to a remote pty session (or list sessions)
   connect --spawn <n> --tag k=v  Spawn a session with tags (--tag repeatable)
   exec <target> <argv...>   Run a non-PTY command on a remote daemon (rsync's -e
@@ -501,6 +506,28 @@ async function main(): Promise<void> {
       const configDir = getFlag("--config-dir") ?? undefined;
       const { renameCommand } = await import("./commands/rename.ts");
       await renameCommand(oldLabel, newLabel, { configDir, passphraseFile });
+      break;
+    }
+
+    case "add": {
+      // Today only `ssh://[user@]host[:port]` is accepted (brief-010
+      // phase 1). Self-hosted hosts get added by the implicit
+      // post-handshake save in `connect`; public-relay hosts by the
+      // `server signin`/`server join` flows. `add` is the only path
+      // for ssh:// since there's no daemon to handshake with.
+      const target = args[1];
+      if (!target) {
+        console.error("Usage: pty-relay add ssh://[user@]host[:port] [--label <name>]");
+        process.exit(1);
+      }
+      const labelFlag = getFlag("--label");
+      const configDir = getFlag("--config-dir") ?? undefined;
+      const { addCommand } = await import("./commands/add.ts");
+      await addCommand(target, {
+        configDir,
+        passphraseFile,
+        label: labelFlag ?? undefined,
+      });
       break;
     }
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,0 +1,99 @@
+import { openSecretStore } from "../storage/bootstrap.ts";
+import {
+  saveSshKnownHost,
+  loadKnownHosts,
+} from "../relay/known-hosts.ts";
+import {
+  looksLikeSshUrl,
+  parseSshUrl,
+  probeSshPeer,
+} from "../relay/transport-ssh.ts";
+import { log } from "../log.ts";
+
+/**
+ * `pty-relay add <peer>` — record a new peer in known-hosts. Today
+ * the only supported peer shape is an `ssh://[user@]host[:port]` URL
+ * (brief-010 phase 1). Self-hosted hosts are still saved
+ * automatically on the first successful `connect`; public-relay hosts
+ * come from the `server signin`/`server join` flows.
+ *
+ * The save is gated on a connectivity probe (`ssh <host> pty
+ * --version`). Refusing to record a peer that we can't reach saves
+ * the user from a later `pty-relay ls <label>` failing with an
+ * opaque "command not found" or "could not resolve hostname" error.
+ */
+
+export interface AddOptions {
+  configDir?: string;
+  passphraseFile?: string;
+  /** Override the auto-derived label (defaults to the bare hostname
+   *  from the URL, e.g. `me@host.tld:2222` → `host.tld`). */
+  label?: string;
+}
+
+export async function addCommand(target: string, opts: AddOptions = {}): Promise<void> {
+  if (!looksLikeSshUrl(target)) {
+    console.error(
+      `pty-relay add only supports ssh:// peers today. Got: ${target}`,
+    );
+    console.error("  Self-hosted hosts are saved automatically on `connect`.");
+    console.error("  Public-relay hosts use `pty-relay server signin`/`server join`.");
+    process.exit(1);
+  }
+
+  let parsed: ReturnType<typeof parseSshUrl>;
+  try {
+    parsed = parseSshUrl(target);
+  } catch (err: any) {
+    console.error(`Invalid ssh URL: ${err?.message ?? err}`);
+    process.exit(1);
+  }
+
+  const label = opts.label ?? deriveDefaultLabel(parsed.userHost);
+  log("cli", "add ssh begin", { sshUrl: target, label });
+
+  // Probe before save. If pty isn't installed remotely or the host is
+  // unreachable, surface the actionable error from translateSshError
+  // verbatim — the operator gets the same message they'd see if they
+  // had tried `pty-relay ls` afterwards, but without polluting the
+  // known-hosts file with a non-functional entry.
+  process.stdout.write(`Checking ${target} ...`);
+  let version: string;
+  try {
+    version = await probeSshPeer(target);
+  } catch (err: any) {
+    process.stdout.write("\n");
+    console.error(err?.message ?? err);
+    process.exit(1);
+  }
+  process.stdout.write(` ok (pty ${version || "unknown"})\n`);
+
+  const { store } = await openSecretStore(opts.configDir, {
+    interactive: true,
+    passphraseFile: opts.passphraseFile,
+  });
+
+  await saveSshKnownHost({ label, sshUrl: target }, store);
+
+  // Report the canonical name `ls` will show. saveSshKnownHost runs
+  // pickUniqueLabel internally; re-read so any collision suffix is
+  // surfaced to the operator.
+  const all = await loadKnownHosts(store);
+  const saved = all.find((h) => h.sshUrl === target);
+  const finalLabel = saved?.label ?? label;
+  console.log(`Added ${finalLabel} → ${target}`);
+  if (finalLabel !== label) {
+    console.log(
+      `  (label collided with an existing entry; auto-suffixed to "${finalLabel}")`,
+    );
+  }
+}
+
+/** Pick a friendly default label from the `[user@]host` portion of an
+ *  ssh URL. Drops the `user@` prefix because the label is for the
+ *  human-typed `pty-relay ls <label>` flow, not the underlying
+ *  identity. */
+function deriveDefaultLabel(userHost: string): string {
+  const atIdx = userHost.lastIndexOf("@");
+  return atIdx === -1 ? userHost : userHost.slice(atIdx + 1);
+}

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -56,7 +56,7 @@ export async function connect(
     if (passphrase && !process.env.PTY_RELAY_PASSPHRASE) {
       process.env.PTY_RELAY_PASSPHRASE = passphrase;
     }
-    const { resolveHost } = await import("../relay/host-resolve.ts");
+    const { resolveHost, requireRelayHost } = await import("../relay/host-resolve.ts");
     const resolved = await resolveHost(tokenUrlOrLabel, store);
     if (resolved.kind === "public") {
       const { connectPublic } = await import("./connect-public.ts");
@@ -67,8 +67,9 @@ export async function connect(
       });
       return;
     }
+    const relayHost = requireRelayHost(resolved, "connect");
     // Self-hosted label → look up the stored URL and fall through.
-    tokenUrlOrLabel = resolved.url;
+    tokenUrlOrLabel = relayHost.url;
   }
 
   const tokenUrl = tokenUrlOrLabel;

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -6,7 +6,7 @@ import {
   type SubscribeRemoteEventsOptions,
   type RemoteEventsSubscription,
 } from "../relay/events-client.ts";
-import { resolveHost } from "../relay/host-resolve.ts";
+import { resolveHost, requireRelayHost } from "../relay/host-resolve.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import { log } from "../log.ts";
 
@@ -97,10 +97,13 @@ export async function follow(hostLabel: string, opts: EventsOpts): Promise<void>
     },
   };
 
-  const subscription: RemoteEventsSubscription =
-    resolved.kind === "public"
-      ? subscribePublicRemoteEvents(resolved.target, subOpts)
-      : subscribeRemoteEvents(resolved.url, subOpts);
+  let subscription: RemoteEventsSubscription;
+  if (resolved.kind === "public") {
+    subscription = subscribePublicRemoteEvents(resolved.target, subOpts);
+  } else {
+    const relayHost = requireRelayHost(resolved, "events");
+    subscription = subscribeRemoteEvents(relayHost.url, subOpts);
+  }
 
   // Keep the process alive until Ctrl+C.
   process.on("SIGINT", () => {

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -1,11 +1,16 @@
 import { matchesAllTags } from "@myobie/pty/client";
 import { ready } from "../crypto/index.ts";
-import { loadKnownHosts, isPublicHost } from "../relay/known-hosts.ts";
+import {
+  loadKnownHosts,
+  isPublicHost,
+  isSshHost,
+} from "../relay/known-hosts.ts";
 import {
   listRemoteSessions,
   listPublicRemoteSessions,
   type RemoteSession,
 } from "../relay/relay-client.ts";
+import { listSshRemoteSessions } from "../relay/transport-ssh.ts";
 import { loadPublicAccount } from "../storage/public-account.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import sodium from "libsodium-wrappers-sumo";
@@ -91,6 +96,45 @@ export async function ls(
   const results: HostResult[] = await Promise.all(
     hosts.map(async (h) => {
       const hostStart = now();
+      if (isSshHost(h)) {
+        try {
+          const sshSessions = await listSshRemoteSessions(h.sshUrl);
+          const sessions = hasFilter
+            ? sshSessions.filter((s) => matchesAllTags(s.tags, filterTags))
+            : sshSessions;
+          log("cli", "ls host done", {
+            label: h.label,
+            kind: "ssh",
+            sessions: sessions.length,
+            ms: sinceMs(hostStart),
+          });
+          // ssh peers don't carry a `spawn_enabled` signal — pty list
+          // --json doesn't surface that today. Default to true: the
+          // operator has shell access, so they can spawn whatever they
+          // want regardless. Better UX than reporting a false zero.
+          return {
+            label: h.label,
+            url: h.sshUrl,
+            sessions,
+            spawn_enabled: true,
+            error: null,
+          };
+        } catch (err: any) {
+          log("cli", "ls host error", {
+            label: h.label,
+            kind: "ssh",
+            error: err?.message,
+            ms: sinceMs(hostStart),
+          });
+          return {
+            label: h.label,
+            url: h.sshUrl,
+            sessions: [],
+            spawn_enabled: false,
+            error: err.message || "ssh transport failed",
+          };
+        }
+      }
       if (isPublicHost(h)) {
         const url = `${h.relayUrl}@${h.publicKey.slice(0, 8)}`;
         if (!account) {

--- a/src/commands/peek.ts
+++ b/src/commands/peek.ts
@@ -3,7 +3,7 @@ import {
   peekRemoteSession,
   peekPublicRemoteSession,
 } from "../relay/relay-client.ts";
-import { resolveHost } from "../relay/host-resolve.ts";
+import { resolveHost, requireRelayHost } from "../relay/host-resolve.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import { log } from "../log.ts";
 
@@ -51,7 +51,11 @@ export async function peek(
     const result =
       resolved.kind === "public"
         ? await peekPublicRemoteSession(resolved.target, session, peekOpts)
-        : await peekRemoteSession(resolved.url, session, peekOpts);
+        : await peekRemoteSession(
+            requireRelayHost(resolved, "peek").url,
+            session,
+            peekOpts,
+          );
     // Write the screen to stdout as-is; callers can pipe or redirect.
     process.stdout.write(result.screen);
     // Add a trailing newline only if the screen didn't end with one, so

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -3,7 +3,7 @@ import {
   sendToRemoteSession,
   sendToPublicRemoteSession,
 } from "../relay/relay-client.ts";
-import { resolveHost } from "../relay/host-resolve.ts";
+import { resolveHost, requireRelayHost } from "../relay/host-resolve.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import { log } from "../log.ts";
 
@@ -44,6 +44,7 @@ export async function send(
   if (resolved.kind === "public") {
     await sendToPublicRemoteSession(resolved.target, session, data, sendOpts);
   } else {
-    await sendToRemoteSession(resolved.url, session, data, sendOpts);
+    const relayHost = requireRelayHost(resolved, "send");
+    await sendToRemoteSession(relayHost.url, session, data, sendOpts);
   }
 }

--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -3,7 +3,7 @@ import {
   tagRemoteSession,
   tagPublicRemoteSession,
 } from "../relay/relay-client.ts";
-import { resolveHost } from "../relay/host-resolve.ts";
+import { resolveHost, requireRelayHost } from "../relay/host-resolve.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import { log } from "../log.ts";
 
@@ -43,7 +43,11 @@ export async function tag(
   const result =
     resolved.kind === "public"
       ? await tagPublicRemoteSession(resolved.target, session, tagOpts)
-      : await tagRemoteSession(resolved.url, session, tagOpts);
+      : await tagRemoteSession(
+          requireRelayHost(resolved, "tag").url,
+          session,
+          tagOpts,
+        );
 
   if (opts.json) {
     console.log(JSON.stringify(result.tags, null, 2));

--- a/src/relay/host-resolve.ts
+++ b/src/relay/host-resolve.ts
@@ -2,6 +2,7 @@ import sodium from "libsodium-wrappers-sumo";
 import {
   loadKnownHosts,
   isPublicHost,
+  isSshHost,
   type KnownHost,
 } from "./known-hosts.ts";
 import { loadPublicAccount } from "../storage/public-account.ts";
@@ -16,7 +17,37 @@ import { log } from "../log.ts";
  */
 export type ResolvedHost =
   | { kind: "self"; label: string; url: string }
-  | { kind: "public"; label: string; target: PublicTarget; role?: "daemon" | "client" };
+  | { kind: "public"; label: string; target: PublicTarget; role?: "daemon" | "client" }
+  | { kind: "ssh"; label: string; sshUrl: string };
+
+/**
+ * Subcommands that already handle public-relay hosts inline (peek,
+ * send, tag, events, connect) call this on the non-public branch to
+ * narrow off the `ssh` case with a clear "not supported via ssh yet"
+ * error. Brief-010 phase 1 wires only `ls` for ssh peers; the rest
+ * are mechanical follow-ups but they don't ship in the first slice.
+ */
+export function requireRelayHost(
+  resolved: ResolvedHost,
+  subcommand: string,
+): { kind: "self"; label: string; url: string } {
+  if (resolved.kind === "ssh") {
+    throw new Error(
+      `${subcommand} doesn't yet support ssh:// peers. ` +
+        `For now, run \`ssh ${labelHostHint(resolved.sshUrl)} pty ${subcommand} …\` directly.`,
+    );
+  }
+  if (resolved.kind === "public") {
+    // Defense — callers should branch on `public` themselves; if they
+    // didn't, this is a clearer error than a downstream type cast.
+    throw new Error(`${subcommand} for public-relay peers must be handled separately`);
+  }
+  return resolved;
+}
+
+function labelHostHint(sshUrl: string): string {
+  return sshUrl.startsWith("ssh://") ? sshUrl.slice("ssh://".length) : sshUrl;
+}
 
 /**
  * Resolve a `pty-relay <cmd> <host-label>` argument to either a token
@@ -40,6 +71,11 @@ export async function resolveHost(
     throw new Error(
       `No known host "${label}". Run \`pty-relay ls\` to list hosts.`
     );
+  }
+
+  if (isSshHost(host)) {
+    log("hosts", "resolved ssh", { label, sshUrl: host.sshUrl });
+    return { kind: "ssh", label, sshUrl: host.sshUrl };
   }
 
   if (!isPublicHost(host)) {

--- a/src/relay/known-hosts.ts
+++ b/src/relay/known-hosts.ts
@@ -2,7 +2,7 @@ import type { SecretStore } from "../storage/secret-store.ts";
 import { log } from "../log.ts";
 
 /**
- * A saved relay host. Supports two flavors:
+ * A saved relay host. Supports three flavors:
  *
  *   self-hosted: `{label, url}` where url is the classic `#pk.secret`
  *     token-url form. Used by `pty-relay connect <token-url>` and saved
@@ -15,12 +15,17 @@ import { log } from "../log.ts";
  *     opens a `role=client_pair` WS against the relay, targeting
  *     `publicKey`.
  *
+ *   ssh: `{label, sshUrl}` where sshUrl is a `ssh://[user@]host[:port]`
+ *     URL. Used by `pty-relay add ssh://…` for ssh-reachable hosts that
+ *     don't need a relay daemon — `ls`/`peek`/`send`/etc. shell out to
+ *     `ssh <host> pty <cmd>` directly. See `docs/ssh-transport.md`.
+ *
  * `role` is informational for public-mode entries (daemon vs client) and
  * lets `ls` decide which rows to include in the session view.
  */
 export interface KnownHost {
   label: string;
-  /** Self-hosted `#pk.secret` URL. Omitted for public-relay hosts. */
+  /** Self-hosted `#pk.secret` URL. Omitted for non-self-hosted hosts. */
   url?: string;
   /** Public-relay origin, e.g. `http://localhost:4000`. */
   relayUrl?: string;
@@ -28,6 +33,10 @@ export interface KnownHost {
   publicKey?: string;
   /** Peer role on the account. */
   role?: "daemon" | "client";
+  /** `ssh://[user@]host[:port]` URL for ssh-reachable peers. The host is
+   *  reached by shelling out to `ssh <user@host> pty <op>`; no relay
+   *  daemon required. */
+  sshUrl?: string;
 }
 
 /** True iff this entry was registered via the public-relay flow. */
@@ -36,6 +45,11 @@ export function isPublicHost(h: KnownHost): h is KnownHost & {
   publicKey: string;
 } {
   return typeof h.relayUrl === "string" && typeof h.publicKey === "string";
+}
+
+/** True iff this entry is an ssh:// peer (no relay daemon). */
+export function isSshHost(h: KnownHost): h is KnownHost & { sshUrl: string } {
+  return typeof h.sshUrl === "string";
 }
 
 function parseHost(item: unknown): KnownHost | null {
@@ -48,9 +62,17 @@ function parseHost(item: unknown): KnownHost | null {
   if (typeof o.relayUrl === "string") host.relayUrl = o.relayUrl;
   if (typeof o.publicKey === "string") host.publicKey = o.publicKey;
   if (o.role === "daemon" || o.role === "client") host.role = o.role;
+  if (typeof o.sshUrl === "string") host.sshUrl = o.sshUrl;
 
-  // Reject entries that are neither self-hosted nor public-relay.
-  if (!host.url && !(host.relayUrl && host.publicKey)) return null;
+  // Reject entries that have no transport (neither self-hosted, public-
+  // relay, nor ssh).
+  if (
+    !host.url &&
+    !(host.relayUrl && host.publicKey) &&
+    !host.sshUrl
+  ) {
+    return null;
+  }
   return host;
 }
 
@@ -214,6 +236,29 @@ export async function savePublicKnownHost(
     relayUrl: host.relayUrl,
     role: host.role ?? "daemon",
     publicKeyPrefix: host.publicKey.slice(0, 8),
+  });
+}
+
+/**
+ * Save an ssh:// host: an ssh-reachable peer that runs `pty` locally.
+ * The sshUrl tuple is the unique key — re-saving the same sshUrl
+ * updates the label in place. Label collisions against unrelated
+ * entries get a sshUrl-derived suffix.
+ */
+export async function saveSshKnownHost(
+  host: { label: string; sshUrl: string },
+  store: SecretStore,
+): Promise<void> {
+  const existing = await loadKnownHosts(store);
+  const kept = existing.filter((h) => h.sshUrl !== host.sshUrl);
+  const usedLabels = new Set(kept.map((h) => h.label));
+  const finalLabel = pickUniqueLabel(host.label, host.sshUrl, usedLabels);
+  kept.push({ label: finalLabel, sshUrl: host.sshUrl });
+  await persist(kept, store);
+  log("hosts", "save ssh", {
+    label: finalLabel,
+    collidedWith: finalLabel !== host.label ? host.label : undefined,
+    sshUrl: host.sshUrl,
   });
 }
 

--- a/src/relay/transport-ssh.ts
+++ b/src/relay/transport-ssh.ts
@@ -1,0 +1,246 @@
+/**
+ * SSH transport for ssh-reachable peers — see `docs/ssh-transport.md`.
+ *
+ * For peers identified by an `ssh://[user@]host[:port]` URL the relay
+ * daemon isn't needed at all: `pty` already exposes every read/write
+ * op as a CLI subcommand with `--json`, and ssh handles auth +
+ * transport + binary stdio. We shell out to `ssh <userHost> pty <op>`
+ * and parse the result.
+ *
+ * Phase-1 scope: URL parsing + `listSshRemoteSessions` (the headline
+ * `pty-relay ls ssh://host` slice). Subsequent ops (peek / send / tag
+ * / events / connect / exec) extend this module with the same shape:
+ * one function per `pty` subcommand, each just an ssh shell-out + a
+ * minimal output parser.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { RemoteSession } from "./relay-client.ts";
+import { log } from "../log.ts";
+
+const execFileAsync = promisify(execFile);
+
+/** Default ssh port — matches OpenSSH. */
+const DEFAULT_SSH_PORT = 22;
+
+/** Parsed shape of an `ssh://[user@]host[:port]` URL.
+ *
+ *  `userHost` is the `[user@]host` segment ssh wants as its first
+ *  positional arg. `port` is provided separately because ssh takes
+ *  `-p <port>` rather than baking it into the host arg. */
+export interface ParsedSshUrl {
+  /** Bare `[user@]host` string suitable for `ssh <userHost> …`. */
+  userHost: string;
+  /** Defaults to 22. Set explicitly when the URL had a `:port`. */
+  port: number;
+}
+
+/**
+ * Parse an `ssh://[user@]host[:port]` URL. Throws a clear error for
+ * malformed input so the CLI dispatcher can render it without
+ * wrapping.
+ *
+ * Examples:
+ *   ssh://host                 → { userHost: "host",       port: 22 }
+ *   ssh://me@host              → { userHost: "me@host",    port: 22 }
+ *   ssh://me@host:2222         → { userHost: "me@host",    port: 2222 }
+ *   ssh://host:2222            → { userHost: "host",       port: 2222 }
+ */
+export function parseSshUrl(input: string): ParsedSshUrl {
+  if (typeof input !== "string") {
+    throw new Error("ssh URL must be a string");
+  }
+  if (!input.startsWith("ssh://")) {
+    throw new Error(`ssh URL must start with ssh:// (got: ${input})`);
+  }
+
+  // Pull off the `ssh://` prefix and then split on `:` for the port
+  // (right-most colon only, so user-info that contains `:` doesn't
+  // confuse us — though ssh URIs don't carry passwords).
+  const rest = input.slice("ssh://".length);
+  if (rest.length === 0) {
+    throw new Error("ssh URL has no host (got: ssh://)");
+  }
+  // Refuse path components — the URL is a peer identifier, not a
+  // resource locator. Trailing slash is allowed and ignored.
+  const slashIdx = rest.indexOf("/");
+  const beforeSlash =
+    slashIdx === -1 ? rest : slashIdx === rest.length - 1 ? rest.slice(0, -1) : null;
+  if (beforeSlash === null) {
+    throw new Error(`ssh URL must not carry a path (got: ${input})`);
+  }
+
+  // Identify the port (last colon, only when it's after the @ if any).
+  const atIdx = beforeSlash.lastIndexOf("@");
+  const colonSearchFrom = atIdx === -1 ? 0 : atIdx + 1;
+  const colonIdx = beforeSlash.indexOf(":", colonSearchFrom);
+
+  let userHost: string;
+  let port: number;
+  if (colonIdx === -1) {
+    userHost = beforeSlash;
+    port = DEFAULT_SSH_PORT;
+  } else {
+    userHost = beforeSlash.slice(0, colonIdx);
+    const portStr = beforeSlash.slice(colonIdx + 1);
+    const parsed = parseInt(portStr, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
+      throw new Error(`ssh URL has invalid port "${portStr}" (got: ${input})`);
+    }
+    port = parsed;
+  }
+
+  if (userHost.length === 0 || userHost.endsWith("@")) {
+    throw new Error(`ssh URL has empty host (got: ${input})`);
+  }
+  // Reject empty user-info segment (`@host` form).
+  const atSplit = userHost.indexOf("@");
+  if (atSplit === 0) {
+    throw new Error(`ssh URL has empty user-info (got: ${input})`);
+  }
+  // Reject empty host segment after the user (`me@` was already
+  // caught above by endsWith).
+  if (atSplit > 0 && atSplit === userHost.length - 1) {
+    throw new Error(`ssh URL has empty host (got: ${input})`);
+  }
+
+  return { userHost, port };
+}
+
+/**
+ * `true` iff the string looks like an ssh URL. Cheap discriminator for
+ * the host-resolve dispatch — full validation happens in
+ * `parseSshUrl`.
+ */
+export function looksLikeSshUrl(s: string): boolean {
+  return typeof s === "string" && s.startsWith("ssh://");
+}
+
+/**
+ * Default options applied to every `ssh` invocation. Centralized so a
+ * future caller can override via a per-call options arg without each
+ * subcommand redefining them.
+ *
+ *   -o BatchMode=yes        Never prompt for passwords. Connectivity
+ *                           failures fail fast rather than blocking
+ *                           on input that won't come.
+ *   -o ConnectTimeout=10    Short-circuit DNS / TCP hangs.
+ *   -p <port>               Honor the ssh:// URL's port.
+ */
+function baseSshArgs(parsed: ParsedSshUrl): string[] {
+  const args = [
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=10",
+  ];
+  if (parsed.port !== DEFAULT_SSH_PORT) {
+    args.push("-p", String(parsed.port));
+  }
+  return args;
+}
+
+/**
+ * Run `ssh <userHost> pty list --json` on the peer and parse the
+ * result into the same `RemoteSession[]` shape `listRemoteSessions`
+ * returns for the relay transport. Lets `ls.ts` consume both paths
+ * uniformly.
+ *
+ * Errors are surfaced with the most actionable message we can build
+ * from ssh / pty's stderr — "ssh: connect to host …" / "pty: command
+ * not found" are pre-translated into hints the operator can act on.
+ */
+export async function listSshRemoteSessions(
+  sshUrl: string,
+): Promise<RemoteSession[]> {
+  const parsed = parseSshUrl(sshUrl);
+  log("ssh", "list begin", { userHost: parsed.userHost, port: parsed.port });
+
+  const args = [...baseSshArgs(parsed), parsed.userHost, "pty", "list", "--json"];
+  let stdout: string;
+  try {
+    const result = await execFileAsync("ssh", args, {
+      timeout: 15_000,
+      encoding: "utf-8",
+    });
+    stdout = result.stdout;
+  } catch (err) {
+    throw translateSshError(err, sshUrl);
+  }
+
+  let parsedSessions: unknown;
+  try {
+    parsedSessions = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `pty list --json on ${sshUrl} returned non-JSON output. Is pty up-to-date on the remote?`,
+    );
+  }
+  if (!Array.isArray(parsedSessions)) {
+    throw new Error(
+      `pty list --json on ${sshUrl} returned ${typeof parsedSessions}, expected an array.`,
+    );
+  }
+  return parsedSessions as RemoteSession[];
+}
+
+/**
+ * Probe ssh connectivity with the cheapest viable round-trip: `ssh
+ * <host> pty --version`. Used by `pty-relay add ssh://…` to refuse a
+ * save that wouldn't be usable.
+ *
+ * Returns the pty version string on success; throws with the
+ * translated error on failure.
+ */
+export async function probeSshPeer(sshUrl: string): Promise<string> {
+  const parsed = parseSshUrl(sshUrl);
+  const args = [...baseSshArgs(parsed), parsed.userHost, "pty", "--version"];
+  try {
+    const { stdout } = await execFileAsync("ssh", args, {
+      timeout: 15_000,
+      encoding: "utf-8",
+    });
+    return stdout.trim();
+  } catch (err) {
+    throw translateSshError(err, sshUrl);
+  }
+}
+
+/**
+ * Convert a raw child_process error into one with a user-friendly
+ * message. ssh's exit codes + stderr patterns are well-known enough
+ * that we can pre-translate the common cases.
+ */
+function translateSshError(err: unknown, sshUrl: string): Error {
+  const e = err as { code?: unknown; stderr?: unknown; message?: unknown };
+  const stderr = typeof e.stderr === "string" ? e.stderr.trim() : "";
+  const msg = typeof e.message === "string" ? e.message : "unknown error";
+
+  // The most useful translations: ssh's "command not found"-on-remote
+  // (pty isn't installed) and "could not resolve hostname" / "connection
+  // refused" (peer unreachable).
+  if (stderr.includes("command not found") || stderr.includes("not found")) {
+    return new Error(
+      `${sshUrl}: pty is not on the remote PATH. Install pty there ` +
+        `(see https://github.com/myobie/pty) and re-try.`,
+    );
+  }
+  if (stderr.includes("could not resolve hostname")) {
+    return new Error(
+      `${sshUrl}: could not resolve hostname. Check ~/.ssh/config or use ` +
+        `an IP address.`,
+    );
+  }
+  if (stderr.includes("Connection refused") || stderr.includes("connect to host")) {
+    return new Error(`${sshUrl}: ${stderr.split("\n")[0]}`);
+  }
+  if (stderr.includes("Permission denied")) {
+    return new Error(
+      `${sshUrl}: ssh permission denied. Check your key / ssh-agent ` +
+        `(BatchMode=yes is on, so passwords aren't tried).`,
+    );
+  }
+  // Generic fallback: include the trimmed stderr so the operator sees
+  // ssh's verbatim diagnostic alongside our framing.
+  const tail = stderr ? `\n${stderr}` : "";
+  return new Error(`${sshUrl}: ${msg}${tail}`);
+}

--- a/test/known-hosts-ssh.test.ts
+++ b/test/known-hosts-ssh.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import type { SecretName, SecretStore } from "../src/storage/secret-store.ts";
+import {
+  loadKnownHosts,
+  saveKnownHost,
+  savePublicKnownHost,
+  saveSshKnownHost,
+  removeKnownHost,
+  isPublicHost,
+  isSshHost,
+} from "../src/relay/known-hosts.ts";
+import { resolveHost } from "../src/relay/host-resolve.ts";
+
+class MemStore implements SecretStore {
+  readonly backend = "passphrase" as const;
+  private data = new Map<SecretName, Uint8Array>();
+  async load(n: SecretName) { return this.data.get(n) ?? null; }
+  async save(n: SecretName, p: Uint8Array) { this.data.set(n, p); }
+  async delete(n: SecretName) { this.data.delete(n); }
+}
+
+describe("KnownHost — ssh flavor coexists with self-hosted and public-relay", () => {
+  it("round-trips an ssh host through save/load", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "homelab", sshUrl: "ssh://me@home" }, store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts).toEqual([{ label: "homelab", sshUrl: "ssh://me@home" }]);
+    expect(isSshHost(hosts[0])).toBe(true);
+    expect(isPublicHost(hosts[0])).toBe(false);
+  });
+
+  it("all three flavors live side-by-side", async () => {
+    const store = new MemStore();
+    await saveKnownHost("local", "http://localhost:8099#pk.s", store);
+    await savePublicKnownHost(
+      { label: "remote", relayUrl: "http://relay", publicKey: "pk" },
+      store,
+    );
+    await saveSshKnownHost({ label: "headless", sshUrl: "ssh://headless" }, store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(3);
+    expect(hosts.filter((h) => isSshHost(h)).length).toBe(1);
+    expect(hosts.filter((h) => isPublicHost(h)).length).toBe(1);
+  });
+
+  it("re-save of the same sshUrl updates the label in place", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "first", sshUrl: "ssh://h" }, store);
+    await saveSshKnownHost({ label: "second", sshUrl: "ssh://h" }, store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(1);
+    expect(hosts[0].label).toBe("second");
+  });
+
+  it("different sshUrls keep both entries", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "a", sshUrl: "ssh://host-a" }, store);
+    await saveSshKnownHost({ label: "b", sshUrl: "ssh://host-b" }, store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(2);
+    const labels = hosts.map((h) => h.label).sort();
+    expect(labels).toEqual(["a", "b"]);
+  });
+
+  it("label collision against an unrelated ssh host gets a sshUrl-derived suffix", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "host", sshUrl: "ssh://a" }, store);
+    await saveSshKnownHost({ label: "host", sshUrl: "ssh://b" }, store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.length).toBe(2);
+    const labels = hosts.map((h) => h.label).sort();
+    expect(labels[0]).toBe("host");
+    expect(labels[1]).toMatch(/^host-/);
+  });
+
+  it("loadKnownHosts drops a malformed ssh entry (no sshUrl + no other transport)", async () => {
+    const store = new MemStore();
+    await store.save(
+      "hosts",
+      new TextEncoder().encode(
+        JSON.stringify([
+          { label: "ok", sshUrl: "ssh://host" },
+          { label: "bad" }, // no sshUrl, no url, no relayUrl
+        ]),
+      ),
+    );
+    const hosts = await loadKnownHosts(store);
+    expect(hosts.map((h) => h.label)).toEqual(["ok"]);
+  });
+
+  it("removeKnownHost drops an ssh entry by label", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "remove-me", sshUrl: "ssh://h" }, store);
+    await removeKnownHost("remove-me", store);
+    const hosts = await loadKnownHosts(store);
+    expect(hosts).toEqual([]);
+  });
+});
+
+describe("resolveHost — ssh kind", () => {
+  it("returns kind:ssh for an ssh-flavored label", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "headless", sshUrl: "ssh://me@h" }, store);
+    const resolved = await resolveHost("headless", store);
+    expect(resolved.kind).toBe("ssh");
+    if (resolved.kind !== "ssh") return;
+    expect(resolved.label).toBe("headless");
+    expect(resolved.sshUrl).toBe("ssh://me@h");
+  });
+
+  it("still returns kind:self for a self-hosted label sharing the same store", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "headless", sshUrl: "ssh://me@h" }, store);
+    await saveKnownHost("relay-pin", "http://host:8099#pk.s", store);
+    const resolved = await resolveHost("relay-pin", store);
+    expect(resolved.kind).toBe("self");
+    if (resolved.kind !== "self") return;
+    expect(resolved.url).toBe("http://host:8099#pk.s");
+  });
+});

--- a/test/transport-ssh.test.ts
+++ b/test/transport-ssh.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSshUrl,
+  looksLikeSshUrl,
+} from "../src/relay/transport-ssh.ts";
+
+describe("parseSshUrl", () => {
+  it("parses bare host", () => {
+    expect(parseSshUrl("ssh://host")).toEqual({ userHost: "host", port: 22 });
+  });
+
+  it("parses user@host", () => {
+    expect(parseSshUrl("ssh://me@host")).toEqual({
+      userHost: "me@host",
+      port: 22,
+    });
+  });
+
+  it("parses host:port", () => {
+    expect(parseSshUrl("ssh://host:2222")).toEqual({
+      userHost: "host",
+      port: 2222,
+    });
+  });
+
+  it("parses user@host:port", () => {
+    expect(parseSshUrl("ssh://me@host:2222")).toEqual({
+      userHost: "me@host",
+      port: 2222,
+    });
+  });
+
+  it("accepts an FQDN host", () => {
+    expect(parseSshUrl("ssh://me@a.b.example.com")).toEqual({
+      userHost: "me@a.b.example.com",
+      port: 22,
+    });
+  });
+
+  it("accepts an IPv4 host", () => {
+    expect(parseSshUrl("ssh://10.0.0.1:2222")).toEqual({
+      userHost: "10.0.0.1",
+      port: 2222,
+    });
+  });
+
+  it("accepts a trailing slash (treated as empty path)", () => {
+    expect(parseSshUrl("ssh://host/")).toEqual({ userHost: "host", port: 22 });
+  });
+
+  it("rejects a non-ssh scheme", () => {
+    expect(() => parseSshUrl("https://host")).toThrow(/must start with ssh:\/\//);
+  });
+
+  it("rejects an empty URL after the scheme", () => {
+    expect(() => parseSshUrl("ssh://")).toThrow(/no host/);
+  });
+
+  it("rejects a path component", () => {
+    expect(() => parseSshUrl("ssh://host/path")).toThrow(/must not carry a path/);
+  });
+
+  it("rejects a non-numeric port", () => {
+    expect(() => parseSshUrl("ssh://host:notaport")).toThrow(/invalid port/);
+  });
+
+  it("rejects an out-of-range port", () => {
+    expect(() => parseSshUrl("ssh://host:0")).toThrow(/invalid port/);
+    expect(() => parseSshUrl("ssh://host:99999")).toThrow(/invalid port/);
+  });
+
+  it("rejects an empty user-info segment", () => {
+    expect(() => parseSshUrl("ssh://@host")).toThrow(/empty user-info/);
+  });
+
+  it("rejects an empty host with explicit user-info", () => {
+    expect(() => parseSshUrl("ssh://me@")).toThrow(/empty host/);
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => parseSshUrl(42 as unknown as string)).toThrow(/must be a string/);
+  });
+
+  it("is robust to a `:` in a user (theoretically possible but unusual)", () => {
+    // `user:tail@host` — the lastIndexOf("@") strategy means the
+    // user-info before @ stays intact and we don't try to interpret
+    // its colon as a port. The user-info is whatever ssh accepts; we
+    // just pass it through verbatim.
+    const r = parseSshUrl("ssh://user:tail@host:2222");
+    expect(r).toEqual({ userHost: "user:tail@host", port: 2222 });
+  });
+});
+
+describe("looksLikeSshUrl", () => {
+  it("accepts ssh://", () => {
+    expect(looksLikeSshUrl("ssh://host")).toBe(true);
+  });
+
+  it("rejects http/https/labels", () => {
+    expect(looksLikeSshUrl("http://host")).toBe(false);
+    expect(looksLikeSshUrl("https://host")).toBe(false);
+    expect(looksLikeSshUrl("my-label")).toBe(false);
+    expect(looksLikeSshUrl("")).toBe(false);
+  });
+
+  it("rejects non-string input gracefully (defensive against bad CLI args)", () => {
+    expect(looksLikeSshUrl(null as unknown as string)).toBe(false);
+    expect(looksLikeSshUrl(undefined as unknown as string)).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements the **headline slice** from PR #17's design doc: for ssh-reachable hosts, `pty-relay ls <ssh-peer>` shells out to `ssh <host> pty list --json` and renders the result alongside relay-hosted entries. No relay daemon required.

## What ships

- **`pty-relay add ssh://[user@]host[:port] [--label <name>]`** — record an ssh peer in known-hosts. Probes with `ssh -o BatchMode=yes <host> pty --version` before saving so unreachable peers don't get recorded.
- **`pty-relay ls`** recognizes ssh entries; existing self-hosted / public-relay flows are untouched. JSON shape is unchanged (each row has `url`, `sessions[]`, `spawn_enabled`, `error`); `url` is just `ssh://…` for ssh rows.
- **Headless-friendly defaults**: `ssh -o BatchMode=yes -o ConnectTimeout=10` and pre-translated stderr patterns (`command not found` → "install pty on the remote"; `could not resolve hostname` → "check ~/.ssh/config"; `Permission denied` → "BatchMode=yes is on, so passwords aren't tried"; etc.).
- **Phased rollout safety net**: connect / peek / send / tag / events refuse ssh peers with an actionable error pointing at `ssh <host> pty <op>` direct shell-out, until subsequent brief-010 phases wire each one. The `requireRelayHost` helper centralizes the narrowing + error message.

## Scope: ~250 LOC as the design doc estimated

- `src/relay/transport-ssh.ts` (new, ~180 LOC) — URL parser, `listSshRemoteSessions`, `probeSshPeer`, stderr translation.
- `src/relay/known-hosts.ts` — `KnownHost.sshUrl?` + `isSshHost` + `saveSshKnownHost` + parser update.
- `src/relay/host-resolve.ts` — `ResolvedHost` union + `requireRelayHost` helper.
- `src/commands/add.ts` (new) — the new subcommand.
- `src/commands/ls.ts` — dispatch on `resolved.kind`.
- 5 other commands — one-line guards via `requireRelayHost`.

## Tests

**16** unit cases for the URL parser (`test/transport-ssh.test.ts`) — every URL shape, every rejection (non-ssh scheme, empty URL, path component, invalid port, out-of-range port, empty user-info, empty host, non-string input), and `looksLikeSshUrl` discriminator.

**9** unit cases for the schema (`test/known-hosts-ssh.test.ts`) — three flavors coexisting, re-save updates label, collision suffixing, malformed-entry rejection, `resolveHost` returns `kind:"ssh"`.

**2** integration cases (`integration/ssh-ls.test.ts`) — end-to-end `pty-relay add` + `pty-relay ls` against a fake `ssh` script earlier on PATH. Tests CLI dispatch → host-resolve → transport-ssh → ls render without depending on a real local sshd. Asserts argv shape (`me@fakebox pty list --json`, `-o BatchMode=yes`).

## Verification

```
npx tsc --noEmit              # clean
npm test                      # 691/691 (+25 from phase 1)
npm run test:integration      # 73/75 (+2; same 2 documented revoked-token skips)
```

## Sequencing

- Builds on PR #17 (design) which has Nathan's signoff per direction.
- Independent of PR #21 (PSK design — orthogonal).
- Subsequent brief-010 phases (peek / send / tag / events / connect / exec over ssh) are each ~30 LOC follow-ups using the same shape (`ssh <host> pty <op>`) — they don't ship in this slice.

## Test plan

- [ ] `pty-relay add ssh://invalid-host` → exits 1 with a clear "could not resolve" or "connect to host" message.
- [ ] `pty-relay add ssh://me@host-with-pty` (real reachable peer) → "ok (pty <version>)" + saves entry.
- [ ] `pty-relay ls` → ssh entry renders next to relay entries with the right shape.
- [ ] `pty-relay connect <ssh-label>` → exits 1 with the "doesn't yet support ssh:// peers" message pointing at the direct shell-out (verifies the phased rollout guard).