### PR TITLE
feat(psk): brief-006 — PSK auth implementation (Noise_NKpsk2)

### DIFF
--- a/integration/psk-auth.test.ts
+++ b/integration/psk-auth.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  CLI_ENTRY,
+  Session,
+  createTestContext,
+  destroyTestContext,
+  extractTokenUrl,
+  tokenWithSession,
+  track,
+  getPort,
+  type TestContext,
+} from "./helpers/index.ts";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Phase-5 PSK e2e: prove the three matrix cells of
+ * `Noise_NKpsk2` auth — match, server-only, client-only — produce
+ * the expected outcomes end-to-end (not just at the framing layer).
+ *
+ * Each case spawns a real self-hosted relay + a real connect client,
+ * with --psk-file pointing at temp files. The `psk-gen` subcommand is
+ * exercised once at the top to produce a PSK in the documented format.
+ */
+
+let ctx: TestContext;
+let originalSessionDir: string | undefined;
+
+beforeEach(() => {
+  ctx = createTestContext();
+  originalSessionDir = process.env.PTY_SESSION_DIR;
+  process.env.PTY_SESSION_DIR = ctx.stateDir;
+});
+
+afterEach(async () => {
+  await destroyTestContext(ctx);
+  if (originalSessionDir !== undefined) {
+    process.env.PTY_SESSION_DIR = originalSessionDir;
+  } else {
+    delete process.env.PTY_SESSION_DIR;
+  }
+});
+
+function writePskFile(name: string, contents: string): string {
+  const p = path.join(ctx.stateDir, name);
+  fs.writeFileSync(p, contents, { mode: 0o600 });
+  return p;
+}
+
+function generatePskViaCli(): string {
+  // Exercise the actual subcommand so a regression in its plumbing
+  // surfaces here, not just in the unit test.
+  const result = spawnSync(
+    "node",
+    [CLI_ENTRY, "psk-gen"],
+    { encoding: "utf-8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `psk-gen failed: status=${result.status}, stderr=${result.stderr}`,
+    );
+  }
+  const psk = result.stdout.trim();
+  if (psk.length !== 43) {
+    throw new Error(`Expected 43-char PSK from psk-gen, got ${psk.length}: ${psk}`);
+  }
+  return psk;
+}
+
+describe("PSK auth — server-required, client-supplied (Noise_NKpsk2)", () => {
+  it("happy path: matching PSK on both sides → echo round-trip", async () => {
+    const port = getPort();
+    const psk = generatePskViaCli();
+    const pskFile = writePskFile("psk", psk);
+
+    // Start a pty session so the client has something to attach to.
+    const ptySession = await Session.server("bash", [], {
+      rows: 24,
+      cols: 80,
+    });
+    track(ctx, ptySession);
+    await ptySession.attach();
+    await ptySession.waitForText("$", 5000);
+
+    const server = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [
+          CLI_ENTRY,
+          "local",
+          "start",
+          String(port),
+          "--config-dir",
+          path.join(ctx.stateDir, "relay"),
+          "--psk-file",
+          pskFile,
+          "--auto-approve",
+        ],
+        { rows: 24, cols: 200, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    // The startup banner confirms the responder is in PSK mode — the
+    // assertion catches an upstream regression where --psk-file gets
+    // silently dropped through cli.ts → start.ts before the per-client
+    // RelayConnection sees it.
+    await server.waitForText("PSK authentication enabled", 15000);
+    await server.waitForText("Token URL", 15000);
+    const serverScreen = server.screenshot();
+    const baseToken = extractTokenUrl(serverScreen);
+    const token = tokenWithSession(baseToken, ptySession.name);
+
+    const client = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [CLI_ENTRY, "connect", token, "--psk-file", pskFile],
+        { rows: 24, cols: 80, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    await client.waitForText("$", 15000);
+    client.sendKeys("echo psk-handshake-ok\n");
+    await client.waitForText("psk-handshake-ok", 5000);
+  }, 60000);
+
+  it("server has PSK, client doesn't → server REJECTS non-PSK pairing", async () => {
+    const port = getPort();
+    const psk = generatePskViaCli();
+    const pskFile = writePskFile("psk", psk);
+
+    const ptySession = await Session.server("bash", [], {
+      rows: 24,
+      cols: 80,
+    });
+    track(ctx, ptySession);
+    await ptySession.attach();
+    await ptySession.waitForText("$", 5000);
+
+    const server = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [
+          CLI_ENTRY,
+          "local",
+          "start",
+          String(port),
+          "--config-dir",
+          path.join(ctx.stateDir, "relay"),
+          "--psk-file",
+          pskFile,
+          "--auto-approve",
+        ],
+        { rows: 24, cols: 200, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    await server.waitForText("PSK authentication enabled", 15000);
+    await server.waitForText("Token URL", 15000);
+    const baseToken = extractTokenUrl(server.screenshot());
+    const token = tokenWithSession(baseToken, ptySession.name);
+
+    // Connect WITHOUT --psk-file. The client picks plain NK; the
+    // server should refuse via `daemon has PSK configured` because
+    // it has a PSK loaded.
+    const client = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [CLI_ENTRY, "connect", token],
+        { rows: 24, cols: 80, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    // The structured audit log line on the responder + the warn() to
+    // the daemon's stdout are what we assert on — the client sees a
+    // generic disconnect, but the daemon's screen shows the reason.
+    await server.waitForText("REJECTED", 15000);
+    await server.waitForText("daemon has PSK configured", 15000);
+  }, 60000);
+
+  it("client has PSK, server doesn't → server REJECTS NKpsk2 request", async () => {
+    const port = getPort();
+    const psk = generatePskViaCli();
+    const pskFile = writePskFile("psk", psk);
+
+    const ptySession = await Session.server("bash", [], {
+      rows: 24,
+      cols: 80,
+    });
+    track(ctx, ptySession);
+    await ptySession.attach();
+    await ptySession.waitForText("$", 5000);
+
+    // Server WITHOUT --psk-file.
+    const server = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [
+          CLI_ENTRY,
+          "local",
+          "start",
+          String(port),
+          "--config-dir",
+          path.join(ctx.stateDir, "relay"),
+          "--auto-approve",
+        ],
+        { rows: 24, cols: 200, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    await server.waitForText("Token URL", 15000);
+    const baseToken = extractTokenUrl(server.screenshot());
+    const token = tokenWithSession(baseToken, ptySession.name);
+
+    // Client signals psk_required=1 via --psk-file, but the daemon
+    // has none. Construction-time error in beginHandshake. Note: the
+    // audit warn line is only attached when the responder ALSO has a
+    // PSK loaded — in this asymmetric case the failure surfaces via
+    // RelayConnection's normal onError → `Client <id> error:` line.
+    const client = track(
+      ctx,
+      Session.spawn(
+        "node",
+        [CLI_ENTRY, "connect", token, "--psk-file", pskFile],
+        { rows: 24, cols: 80, env: { PTY_SESSION_DIR: ctx.stateDir } },
+      ),
+    );
+
+    await server.waitForText("client requested NKpsk2", 15000);
+    await server.waitForText("no PSK configured", 15000);
+  }, 60000);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,9 @@ Commands:
   clients revoke <id> [-y]  Revoke a client token (prompts for y/N)
   clients invite [--label]  Generate a pre-approved invite URL
   doctor                    Print environment info for troubleshooting
+  psk-gen                   Print a fresh 32-byte PSK (43-char URL-safe-base64
+                              -no-padding) to stdout. Use as --psk-file
+                              contents or PTY_RELAY_PSK env value.
   server                    Public-relay account management (signin, mint, etc.)
   server --help             Show public-relay subcommands
   client signin --email <addr>  Register this device as an account-wide client
@@ -86,6 +89,13 @@ Commands:
 Options:
   --config-dir <dir>        Config directory (default: ~/.local/state/pty/relay)
   --passphrase-file <path>  Read passphrase from file (non-interactive)
+  --psk-file <path>         Load a 32-byte PSK from <path> (43-char
+                              URL-safe-base64-no-padding, one line). When set,
+                              'local start' requires Noise_NKpsk2 from every
+                              client; 'connect' opts the client into NKpsk2
+                              against a PSK-required relay. Generate with
+                              'pty-relay psk-gen'. Also honored via
+                              PTY_RELAY_PSK env (the file wins).
   --backend <b>             Storage backend for init: keychain|passphrase
   --allow-new-sessions             Allow remote clients to start new pty sessions
   --skip-allow-new-sessions-confirmation  Don't prompt before enabling remote spawn
@@ -234,6 +244,11 @@ async function main(): Promise<void> {
   // Global --passphrase-file flag
   const passphraseFile = getFlag("--passphrase-file") ?? undefined;
 
+  // Global --psk-file flag (also honored via PTY_RELAY_PSK env).
+  // Plumbed into local start (responder side) and connect (initiator
+  // side); other subcommands ignore it.
+  const pskFile = getFlag("--psk-file") ?? undefined;
+
   switch (command) {
     case "connect": {
       const tokenUrlOrLabel = args[1];
@@ -254,6 +269,7 @@ async function main(): Promise<void> {
         session: sessionName ?? undefined,
         configDir,
         passphraseFile,
+        pskFile,
       });
       break;
     }
@@ -681,6 +697,18 @@ async function main(): Promise<void> {
 
     case "local": {
       await dispatchLocal();
+      break;
+    }
+
+    case "psk-gen": {
+      // Print a fresh 32-byte PSK to stdout as 43-char URL-safe-base64.
+      // Output is the bare base64 string — no banner, no newline-fence
+      // — so `pty-relay psk-gen > /etc/pty-relay/psk` and `pty-relay
+      // psk-gen | tr -d '\n' | pbcopy` both behave correctly.
+      const { ready } = await import("./crypto/index.ts");
+      await ready();
+      const { generatePsk } = await import("./relay/psk.ts");
+      process.stdout.write(generatePsk() + "\n");
       break;
     }
 
@@ -1114,6 +1142,7 @@ async function dispatchLocal(): Promise<void> {
     const port = parseInt(portArg || "8099", 10);
     const configDir = getFlag("--config-dir") ?? undefined;
     const passphraseFile = getFlag("--passphrase-file") ?? undefined;
+    const pskFile = getFlag("--psk-file") ?? undefined;
     let allowNewSessions = hasFlag("--allow-new-sessions");
     if (allowNewSessions && !hasFlag("--skip-allow-new-sessions-confirmation")) {
       if (!(await confirmAllowSpawn())) {
@@ -1149,6 +1178,7 @@ async function dispatchLocal(): Promise<void> {
       tailscale,
       autoApprove,
       passphraseFile,
+      pskFile,
       bind,
       latencyStats,
       mosh,
@@ -1208,6 +1238,11 @@ Subcommands:
   start --bind <addr>             Bind address (default: all interfaces;
                                    127.0.0.1 when --tailscale is set)
   start --auto-approve            Skip the per-client approval TUI
+  start --psk-file <path>         Require Noise_NKpsk2 from every client and
+                                   load the 32-byte PSK from <path> (43-char
+                                   URL-safe-base64-no-padding). Generate one
+                                   with 'pty-relay psk-gen'. Honored from
+                                   PTY_RELAY_PSK if the flag is omitted.
   start --allow-new-sessions      Let remote clients spawn new pty sessions
                                    (prompts unless --skip-allow-new-sessions-confirmation)
   start -d [--name <label>]       Run detached in a 'pty' session

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -7,15 +7,27 @@ import {
   getWebSocketUrl,
   createToken,
   NK,
+  NKpsk2,
+  type Pattern,
 } from "../crypto/index.ts";
 import type { ParsedToken } from "../crypto/index.ts";
 import { ClientRelayConnection } from "../terminal/client-connection.ts";
 import { Terminal } from "../terminal/terminal.ts";
 import { ChannelConnection } from "../relay/channel-connection.ts";
 import { saveKnownHost } from "../relay/known-hosts.ts";
+import { loadPsk } from "../relay/psk.ts";
 import type { SecretStore } from "../storage/secret-store.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
 import { log } from "../log.ts";
+
+/** Noise auth material chosen at connect-time. NK has no PSK; NKpsk2
+ *  carries one 32-byte pre-shared key supplied by --psk-file /
+ *  PTY_RELAY_PSK. Plumbed through attachSession → attemptConnect so
+ *  every reconnect uses the same material. */
+interface NoiseAuth {
+  pattern: Pattern;
+  preSharedKey?: Uint8Array;
+}
 
 // Reconnect constants
 const RECONNECT_INITIAL_MS = 1000;
@@ -32,6 +44,10 @@ export async function connect(
     session?: string;
     configDir?: string;
     passphraseFile?: string;
+    /** When set, route through Noise_NKpsk2 instead of NK and signal
+     *  `?psk_required=1` on the WS upgrade so the relay echoes the
+     *  pattern back to the daemon. Also honored from `PTY_RELAY_PSK`. */
+    pskFile?: string;
   }
 ): Promise<void> {
   await ready();
@@ -75,7 +91,19 @@ export async function connect(
   const tokenUrl = tokenUrlOrLabel;
   const parsed = parseToken(tokenUrl);
   const secretHash = computeSecretHash(parsed.secret);
-  const wsUrl = getWebSocketUrl(parsed.host, "client", secretHash, undefined, parsed.clientToken ?? undefined);
+
+  // Resolve PSK auth before building the WS URL — when configured we
+  // tack `?psk_required=1` on so the relay echoes `noise_pattern:
+  // "NKpsk2"` back to the daemon in the `paired` message. Both peers
+  // pick the pattern from the same signal.
+  const preSharedKey = await loadPsk({ pskFile: options?.pskFile });
+  const noiseAuth: NoiseAuth = preSharedKey
+    ? { pattern: NKpsk2, preSharedKey }
+    : { pattern: NK };
+  let wsUrl = getWebSocketUrl(parsed.host, "client", secretHash, undefined, parsed.clientToken ?? undefined);
+  if (preSharedKey) {
+    wsUrl += "&psk_required=1";
+  }
 
   const { store, passphrase } = await openSecretStore(options?.configDir, {
     interactive: true,
@@ -99,11 +127,11 @@ export async function connect(
 
   // If no session and no spawn, list sessions and re-exec with the chosen one
   if (!parsed.session && !options?.spawn) {
-    await listAndPick(wsUrl, parsed, tokenUrl, store);
+    await listAndPick(wsUrl, parsed, tokenUrl, store, noiseAuth);
     return;
   }
 
-  attachSession(wsUrl, parsed, store, options);
+  attachSession(wsUrl, parsed, store, noiseAuth, options);
 }
 
 /**
@@ -144,8 +172,9 @@ async function listAndPick(
   parsed: ReturnType<typeof parseToken>,
   tokenUrl: string,
   store: SecretStore,
+  noiseAuth: NoiseAuth,
 ): Promise<void> {
-  const sessions = await fetchSessions(wsUrl, parsed, store);
+  const sessions = await fetchSessions(wsUrl, parsed, store, noiseAuth);
 
   if (sessions.length === 0) {
     console.log("No running sessions.");
@@ -188,6 +217,7 @@ function fetchSessions(
   wsUrl: string,
   parsed: ReturnType<typeof parseToken>,
   store: SecretStore,
+  noiseAuth: NoiseAuth,
 ): Promise<Array<{ name: string; command?: string }>> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -198,8 +228,9 @@ function fetchSessions(
     let channel: ChannelConnection | null = null;
 
     const connection = new ClientRelayConnection(wsUrl, {
-      pattern: NK,
+      pattern: noiseAuth.pattern,
       daemonPublicKey: parsed.publicKey,
+      preSharedKey: noiseAuth.preSharedKey,
     }, {
       onReady: () => {
         // Handshake done — daemon's pubkey verified by the NK pattern.
@@ -292,6 +323,7 @@ function attemptConnect(
   parsed: ParsedToken,
   store: SecretStore,
   session: string,
+  noiseAuth: NoiseAuth,
   options: {
     spawn?: string;
     cwd?: string;
@@ -322,8 +354,9 @@ function attemptConnect(
     }
 
     const connection = new ClientRelayConnection(wsUrl, {
-      pattern: NK,
+      pattern: noiseAuth.pattern,
       daemonPublicKey: parsed.publicKey,
+      preSharedKey: noiseAuth.preSharedKey,
     }, {
       onReady: () => {
         // Handshake done — daemon's pubkey verified by the NK pattern.
@@ -540,6 +573,7 @@ async function connectWithReconnect(
   parsed: ParsedToken,
   store: SecretStore,
   session: string,
+  noiseAuth: NoiseAuth,
   options: {
     spawn?: string;
     cwd?: string;
@@ -557,7 +591,7 @@ async function connectWithReconnect(
   // we only count actual attempts, and reset on successful connections.
 
   while (true) {
-    const reason = await attemptConnect(wsUrl, parsed, store, session, {
+    const reason = await attemptConnect(wsUrl, parsed, store, session, noiseAuth, {
       spawn: options.spawn,
       cwd: options.cwd,
       tags: options.tags,
@@ -631,14 +665,21 @@ async function connectWithReconnect(
  */
 export async function connectEmbedded(
   tokenUrl: string,
-  options: { spawn?: string; cwd?: string; store: SecretStore }
+  options: { spawn?: string; cwd?: string; store: SecretStore; pskFile?: string }
 ): Promise<ConnectResult> {
   await ready();
   log("cli", "connect embedded begin", { spawn: options.spawn, cwd: options.cwd });
 
   const parsed = parseToken(tokenUrl);
   const secretHash = computeSecretHash(parsed.secret);
-  const wsUrl = getWebSocketUrl(parsed.host, "client", secretHash, undefined, parsed.clientToken ?? undefined);
+  const preSharedKey = await loadPsk({ pskFile: options.pskFile });
+  const noiseAuth: NoiseAuth = preSharedKey
+    ? { pattern: NKpsk2, preSharedKey }
+    : { pattern: NK };
+  let wsUrl = getWebSocketUrl(parsed.host, "client", secretHash, undefined, parsed.clientToken ?? undefined);
+  if (preSharedKey) {
+    wsUrl += "&psk_required=1";
+  }
 
   // Known-host persistence happens in attemptConnect's `onReady`
   // callback below — after the Noise handshake confirms the daemon's
@@ -656,7 +697,7 @@ export async function connectEmbedded(
   }
   process.on("SIGINT", sigintHandler);
 
-  const result = await connectWithReconnect(wsUrl, parsed, options.store, session, {
+  const result = await connectWithReconnect(wsUrl, parsed, options.store, session, noiseAuth, {
     spawn: options.spawn,
     cwd: options.cwd,
     onStatus: (msg: string) => {
@@ -678,6 +719,7 @@ function attachSession(
   wsUrl: string,
   parsed: ReturnType<typeof parseToken>,
   store: SecretStore,
+  noiseAuth: NoiseAuth,
   options?: { spawn?: string; cwd?: string; tags?: Record<string, string>; configDir?: string },
 ): void {
   const session = options?.spawn || parsed.session!;
@@ -687,7 +729,7 @@ function attachSession(
     process.exit(0);
   });
 
-  connectWithReconnect(wsUrl, parsed, store, session, {
+  connectWithReconnect(wsUrl, parsed, store, session, noiseAuth, {
     spawn: options?.spawn,
     cwd: options?.cwd,
     tags: options?.tags,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -10,6 +10,7 @@ import { SessionBridge } from "../relay/session-bridge.ts";
 import { ChannelConnection } from "../relay/channel-connection.ts";
 import { handleChannelOpenControl } from "../relay/channel-open-handler.ts";
 import { ClientTracker } from "../relay/client-tracker.ts";
+import { loadPsk } from "../relay/psk.ts";
 import { EventFollower } from "@myobie/pty/client";
 import { execFileSync, execSync, spawn as childSpawn } from "node:child_process";
 import type { Config } from "../crypto/index.ts";
@@ -83,6 +84,11 @@ export async function start(
     tailscale?: boolean;
     autoApprove?: boolean;
     passphraseFile?: string;
+    /** Path to a `--psk-file`. When set, every per-client connection
+     *  requires Noise_NKpsk2 with this PSK; plain-NK clients are
+     *  refused. Honored from `PTY_RELAY_PSK` if this option is
+     *  omitted. */
+    pskFile?: string;
     bind?: string;
     /** When true: web UI runs the latency tracker, shows the
      *  toolbar indicator + Stats button, and posts reports to the
@@ -125,6 +131,14 @@ export async function start(
   );
   const label = (await loadLabel(store)) || os.hostname();
   const autoApprove = options?.autoApprove ?? false;
+
+  // PSK (Noise_NKpsk2) is opt-in. When configured, every per-client
+  // RelayConnection enforces NKpsk2 and refuses plain-NK clients;
+  // when null, the daemon stays in NK-only mode. See docs/psk-auth.md.
+  const preSharedKey = await loadPsk({ pskFile: options?.pskFile });
+  if (preSharedKey) {
+    console.log("PSK authentication enabled (Noise_NKpsk2).");
+  }
 
   // Start the relay server, serving the web UI from the bundled browser client
   const htmlPath = path.resolve(import.meta.dirname, "../../browser/dist/index.html");
@@ -316,6 +330,7 @@ export async function start(
         console.log(`Client ${clientId} paired.`);
       },
 
+
       onHandshakeComplete: () => {
         // If the client was approved with a token, send it inside the
         // encrypted tunnel — channel-0 framed v1 app message.
@@ -343,6 +358,28 @@ export async function start(
       onClose: () => {
         teardownClient(clientId);
       },
+    }, {
+      preSharedKey: preSharedKey ?? undefined,
+      // Per-attempt audit log line. Structured INFO; one line per
+      // handshake outcome (ok|fail). Matches docs/psk-auth.md §
+      // "Audit logging": no IP-blocklist, no rate-limit, just a
+      // record an operator can `grep psk_auth` on. Skipped entirely
+      // when no PSK is configured.
+      onPskAuthAttempt: preSharedKey
+        ? (event) => {
+            log("psk-auth", "attempt", {
+              clientId,
+              fingerprint: event.fingerprint,
+              outcome: event.outcome,
+              reason: event.reason,
+            });
+            if (event.outcome === "fail") {
+              console.warn(
+                `[psk-auth] client ${clientId} REJECTED — ${event.reason ?? "unknown"}`
+              );
+            }
+          }
+        : undefined,
     });
 
     channel = new ChannelConnection(

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -32,6 +32,8 @@ export {
   Handshake,
   NK,
   KK,
+  NKpsk2,
+  PSK_LEN,
 } from "./noise.ts";
 export type {
   Pattern,

--- a/src/crypto/noise.ts
+++ b/src/crypto/noise.ts
@@ -120,6 +120,27 @@ function hkdf2(
   return [output1, output2];
 }
 
+/** Three-output HKDF for `MixKeyAndHash(input_key_material)` per Noise
+ *  § 5.2.2. The first output replaces ck, the second is hashed in via
+ *  mixHash, the third is the new cipher key. */
+function hkdf3(
+  chainingKey: Uint8Array,
+  inputKeyMaterial: Uint8Array
+): [Uint8Array, Uint8Array, Uint8Array] {
+  const tempKey = hmacBlake2b(chainingKey, inputKeyMaterial);
+  const output1 = hmacBlake2b(tempKey, new Uint8Array([0x01]));
+  const input2 = new Uint8Array(output1.length + 1);
+  input2.set(output1);
+  input2[output1.length] = 0x02;
+  const output2 = hmacBlake2b(tempKey, input2);
+  const input3 = new Uint8Array(output2.length + 1);
+  input3.set(output2);
+  input3[output2.length] = 0x03;
+  const output3 = hmacBlake2b(tempKey, input3);
+  sodium.memzero(tempKey);
+  return [output1, output2, output3];
+}
+
 // --- SymmetricState, Noise spec § 5.2 ---
 
 class SymmetricState {
@@ -152,6 +173,22 @@ class SymmetricState {
     this.ck = newCk;
     this.cipher = new CipherState(tempK.slice(0, KEY_LEN));
     sodium.memzero(oldCk);
+    sodium.memzero(tempK);
+    sodium.memzero(inputKeyMaterial);
+  }
+
+  /** MixKeyAndHash per Noise § 5.2.2. Used by the `psk` token: HKDF
+   *  the chaining key + PSK into three outputs, replace ck with the
+   *  first, mixHash the second, install the third as the new cipher
+   *  key. The PSK is zeroized after use. */
+  mixKeyAndHash(inputKeyMaterial: Uint8Array): void {
+    const oldCk = this.ck;
+    const [newCk, tempH, tempK] = hkdf3(this.ck, inputKeyMaterial);
+    this.ck = newCk;
+    this.mixHash(tempH);
+    this.cipher = new CipherState(tempK.slice(0, KEY_LEN));
+    sodium.memzero(oldCk);
+    sodium.memzero(tempH);
     sodium.memzero(tempK);
     sodium.memzero(inputKeyMaterial);
   }
@@ -195,16 +232,17 @@ class SymmetricState {
 /**
  * Tokens the handshake engine processes during a MESSAGE. `e` generates
  * and transmits an ephemeral; the four DH tokens mix scalar-mult output
- * into the chaining key. Each message's payload (empty for our usage)
- * is encryptAndHash'd at the end.
+ * into the chaining key. `psk` mixes a 32-byte pre-shared key via
+ * MixKeyAndHash (Noise § 9). Each message's payload (empty for our
+ * usage) is encryptAndHash'd at the end.
  *
  * Patterns like IK / XX also use an `s` token to TRANSMIT a static
- * pubkey in-band. NK and KK — the only patterns we currently ship —
+ * pubkey in-band. NK / KK / NKpsk2 — the patterns we currently ship —
  * pre-share statics via the constructor, so no `s` transmission
  * happens and the engine doesn't handle it. If we ever add such a
  * pattern we'll widen this type + add the token case alongside.
  */
-export type Token = "e" | "ee" | "es" | "se" | "ss";
+export type Token = "e" | "ee" | "es" | "se" | "ss" | "psk";
 
 /** Tokens a PRE-MESSAGE references. Pre-message `s` means "this side's
  *  static is known to the peer in advance" — it's mixed into the
@@ -245,6 +283,28 @@ export const KK: Pattern = {
   ],
 };
 
+/**
+ * NK with a 32-byte PSK mixed at message 2 (after `ee`). Adds a second
+ * authenticator on top of NK's pubkey-pinning: the responder must hold
+ * BOTH the matching static keypair AND the matching PSK; the initiator
+ * must hold BOTH the responder's static pubkey AND the PSK. PSK is
+ * pulled from `HandshakeOptions.preSharedKey` — required + must be
+ * exactly 32 bytes.
+ *
+ * Choice of psk2 (vs psk0 / psk1): see `docs/psk-auth.md` § 2. psk2
+ * means the responder authenticates the initiator on msg 2 with the
+ * PSK as the gate, which matches our "PSK is the headless-friendly
+ * auth gate" use case.
+ */
+export const NKpsk2: Pattern = {
+  name: "Noise_NKpsk2_25519_ChaChaPoly_BLAKE2b",
+  preMessages: { initiator: [], responder: ["s"] },
+  messages: [
+    ["e", "es"],          // -> e, es
+    ["e", "ee", "psk"],   // <- e, ee, psk
+  ],
+};
+
 // --- Handshake engine ---
 
 /** Keys a handshake party may hold. Which are required depends on the
@@ -259,6 +319,10 @@ export interface HandshakeKeys {
 export interface HandshakeOptions extends HandshakeKeys {
   pattern: Pattern;
   initiator: boolean;
+  /** Required (+ exactly 32 bytes) when `pattern.messages` contains a
+   *  `psk` token; rejected otherwise. The engine consumes a defensive
+   *  copy and zeroizes it when the token is processed. */
+  preSharedKey?: Uint8Array;
 }
 
 /** Result of a completed handshake: one CipherState per direction. */
@@ -279,11 +343,18 @@ export interface HandshakeResult {
  * the transport CipherStates. Calling `writeMessage()` or
  * `readMessage()` after that throws.
  */
+/** Size, in bytes, of a Noise PSK (Noise spec § 9). */
+export const PSK_LEN = 32;
+
 export class Handshake {
   private readonly pattern: Pattern;
   private readonly initiator: boolean;
   private readonly s?: { publicKey: Uint8Array; privateKey: Uint8Array };
   private readonly rs?: Uint8Array;
+  /** Defensive copy of the PSK if the pattern uses a `psk` token.
+   *  Zeroized after the token is consumed during writeMessage /
+   *  readMessage. `null` when the pattern has no `psk` token. */
+  private psk: Uint8Array | null = null;
   private ss: SymmetricState;
   private e: { publicKey: Uint8Array; privateKey: Uint8Array } | null = null;
   private re: Uint8Array | null = null;
@@ -296,6 +367,32 @@ export class Handshake {
     this.rs = opts.remoteStaticPublicKey
       ? new Uint8Array(opts.remoteStaticPublicKey)
       : undefined;
+
+    // PSK validation. We reject obvious misconfigurations early so a
+    // mismatched call site can't silently pass a wrong-length key
+    // (which would only surface as a confusing AEAD failure later).
+    const patternUsesPsk = this.pattern.messages.some((tokens) =>
+      tokens.includes("psk"),
+    );
+    if (patternUsesPsk) {
+      if (!opts.preSharedKey) {
+        throw new Error(
+          `${this.pattern.name}: pattern includes "psk" token — pass preSharedKey`,
+        );
+      }
+      if (opts.preSharedKey.length !== PSK_LEN) {
+        throw new Error(
+          `${this.pattern.name}: preSharedKey must be exactly ${PSK_LEN} bytes (got ${opts.preSharedKey.length})`,
+        );
+      }
+      // Defensive copy so the caller can zeroize their copy whenever
+      // they want without breaking us mid-handshake.
+      this.psk = new Uint8Array(opts.preSharedKey);
+    } else if (opts.preSharedKey) {
+      throw new Error(
+        `${this.pattern.name}: pattern has no "psk" token — do NOT pass preSharedKey`,
+      );
+    }
 
     // Validate that the keys the pattern's pre-messages demand are
     // actually supplied. We do this at construction time so a
@@ -367,6 +464,8 @@ export class Handshake {
         this.e = { publicKey: kp.publicKey, privateKey: kp.privateKey };
         this.ss.mixHash(this.e.publicKey);
         parts.push(new Uint8Array(this.e.publicKey));
+      } else if (token === "psk") {
+        this.mixPsk();
       } else {
         this.mixDh(token);
       }
@@ -397,6 +496,8 @@ export class Handshake {
         this.re = new Uint8Array(message.subarray(offset, offset + DH_LEN));
         offset += DH_LEN;
         this.ss.mixHash(this.re);
+      } else if (token === "psk") {
+        this.mixPsk();
       } else {
         this.mixDh(token);
       }
@@ -419,17 +520,39 @@ export class Handshake {
 
     // Best-effort zeroization of any keys we still hold. Ephemeral
     // privates should already be gone from mixDh; static privates are
-    // caller-owned so we leave them alone.
+    // caller-owned so we leave them alone. If `psk` was loaded but
+    // never consumed (e.g. an abandoned mid-handshake split), zeroize
+    // it now so it doesn't linger.
     if (this.e) {
       sodium.memzero(this.e.privateKey);
       this.e = null;
     }
     this.re = null;
+    if (this.psk) {
+      sodium.memzero(this.psk);
+      this.psk = null;
+    }
 
     const [c1, c2] = this.ss.split();
     return this.initiator
       ? { send: c1, recv: c2 }
       : { send: c2, recv: c1 };
+  }
+
+  /** Process the `psk` token: MixKeyAndHash(psk), then zeroize our
+   *  defensive copy. Each psk token in a pattern consumes the PSK
+   *  exactly once — the engine refuses to process a second psk token
+   *  in the same handshake (the patterns we ship never repeat one). */
+  private mixPsk(): void {
+    if (!this.psk) {
+      throw new Error('"psk" token but no PSK is loaded (already consumed?)');
+    }
+    // mixKeyAndHash zeroizes its argument, so the local zeroization
+    // here is redundant — but we explicitly drop the reference too so
+    // a second "psk" token in the same handshake fails clearly above.
+    const psk = this.psk;
+    this.psk = null;
+    this.ss.mixKeyAndHash(psk);
   }
 
   /** Process one DH token. Throws if the required key isn't available. */

--- a/src/relay/psk.ts
+++ b/src/relay/psk.ts
@@ -1,0 +1,154 @@
+/**
+ * Pre-shared key loader for `--psk-file` / `PTY_RELAY_PSK` (server and
+ * client side). See `docs/psk-auth.md` § "CLI surface (headless-
+ * friendly)" for the priority + format contract.
+ *
+ * Resolution order (first found wins):
+ *   1. `opts.pskFile` — absolute or relative path; reads the file's
+ *      first line, trims whitespace.
+ *   2. `PTY_RELAY_PSK` env var — verbatim (trimmed).
+ *
+ * Format: exactly `PSK_LEN`-byte (32-byte) URL-safe-base64-no-padding
+ * (43 chars: 6 bits × 43 = 258 ≥ 32×8 = 256). Anything else is
+ * rejected with a precise error so the operator can fix it without
+ * re-reading the design doc.
+ *
+ * No KDF for v1. PSK is a machine-to-machine secret — treat it like
+ * an SSH key (binary, generated, copied). `generatePsk()` produces a
+ * spec-shape PSK; `pty-relay psk-gen` exposes it on the CLI.
+ */
+
+import * as fs from "node:fs";
+import sodium from "libsodium-wrappers-sumo";
+import { PSK_LEN } from "../crypto/index.ts";
+import { log } from "../log.ts";
+
+export interface LoadPskOptions {
+  /** Path to a file whose first line is the 43-char base64url PSK.
+   *  Whitespace + a trailing newline are trimmed. Read mode 0600 is
+   *  enforced via a stderr warning (not a refusal — operator may
+   *  have intentionally relaxed perms for a deploy). */
+  pskFile?: string;
+  /** Override `process.env.PTY_RELAY_PSK` for tests / non-interactive
+   *  callers that want explicit scoping. Defaults to reading the env
+   *  var directly. */
+  envVar?: string | null;
+}
+
+/**
+ * Resolve a PSK from the operator's environment. Returns `null` when
+ * neither `pskFile` nor `PTY_RELAY_PSK` is present — callers treat
+ * that as "PSK auth not configured."
+ *
+ * Throws (rather than warns) for any of the following — these are
+ * misconfigurations the operator must fix, not graceful fallbacks:
+ *   - `pskFile` is set but the file doesn't exist or can't be read.
+ *   - The decoded byte length isn't `PSK_LEN`.
+ *   - The string isn't a valid URL-safe-base64 sequence.
+ */
+export async function loadPsk(opts: LoadPskOptions = {}): Promise<Uint8Array | null> {
+  const env = opts.envVar !== undefined ? opts.envVar : process.env.PTY_RELAY_PSK;
+
+  let source: string;
+  let raw: string;
+
+  if (opts.pskFile) {
+    source = `--psk-file ${opts.pskFile}`;
+    try {
+      raw = fs.readFileSync(opts.pskFile, "utf-8");
+    } catch (err) {
+      throw new Error(
+        `--psk-file: cannot read ${opts.pskFile}: ${(err as Error).message}`,
+      );
+    }
+    warnIfWorldReadable(opts.pskFile);
+  } else if (typeof env === "string" && env.length > 0) {
+    source = "PTY_RELAY_PSK";
+    raw = env;
+  } else {
+    log("psk", "not configured");
+    return null;
+  }
+
+  // Trim ONE optional trailing newline + any surrounding whitespace.
+  // We intentionally don't tolerate embedded whitespace — typos that
+  // pasted multi-line garbage should fail, not silently truncate.
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) {
+    throw new Error(`${source}: PSK is empty`);
+  }
+  if (/\s/.test(trimmed)) {
+    throw new Error(
+      `${source}: PSK contains whitespace (expected a single 43-char base64url string)`,
+    );
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = sodium.from_base64(trimmed, sodium.base64_variants.URLSAFE_NO_PADDING);
+  } catch (err) {
+    throw new Error(
+      `${source}: PSK isn't valid URL-safe-base64-no-padding (${(err as Error).message})`,
+    );
+  }
+
+  if (bytes.length !== PSK_LEN) {
+    throw new Error(
+      `${source}: PSK decoded to ${bytes.length} bytes; must be exactly ${PSK_LEN}.\n` +
+        `  Generate one with \`pty-relay psk-gen\`.`,
+    );
+  }
+
+  log("psk", "loaded", {
+    source,
+    // Don't log the PSK itself, obviously — fingerprint via a
+    // hash prefix so two daemons can be eyeballed to "same PSK"
+    // without leaking the key.
+    fingerprint: pskFingerprint(bytes),
+  });
+  return bytes;
+}
+
+/**
+ * Generate a fresh PSK as a 43-char URL-safe-base64-no-padding
+ * string. The encoding the operator pastes into `PTY_RELAY_PSK` /
+ * writes to a `--psk-file` and that `loadPsk` round-trips back to 32
+ * bytes.
+ */
+export function generatePsk(): string {
+  const bytes = sodium.randombytes_buf(PSK_LEN);
+  return sodium.to_base64(bytes, sodium.base64_variants.URLSAFE_NO_PADDING);
+}
+
+/**
+ * Short fingerprint of a PSK suitable for logging — a 16-char
+ * URL-safe-base64 prefix of `blake2b(psk)`. Lets two daemons confirm
+ * "same PSK loaded" without exposing the key itself.
+ */
+export function pskFingerprint(psk: Uint8Array): string {
+  const hash = sodium.crypto_generichash(32, psk, null);
+  return sodium
+    .to_base64(hash, sodium.base64_variants.URLSAFE_NO_PADDING)
+    .slice(0, 16);
+}
+
+/** stat the PSK file; warn (don't refuse) if other/group bits are
+ *  set. Mirrors openssh's `Permissions for '<file>' are too open`
+ *  warning — actionable without being draconian about deploy
+ *  configurations where the operator deliberately relaxed perms. */
+function warnIfWorldReadable(pskFile: string): void {
+  try {
+    const stat = fs.statSync(pskFile);
+    const otherReadable = (stat.mode & 0o077) !== 0;
+    if (otherReadable) {
+      process.stderr.write(
+        `Warning: ${pskFile} is readable by group/other (mode 0${(stat.mode & 0o777).toString(8)}).\n` +
+          `  Tighten with \`chmod 600 ${pskFile}\` — PSK shouldn't be world-readable.\n`,
+      );
+    }
+  } catch {
+    // Stat failure isn't actionable for the operator at this point;
+    // the actual read above would have surfaced it already.
+  }
+}

--- a/src/relay/relay-connection.ts
+++ b/src/relay/relay-connection.ts
@@ -4,9 +4,11 @@ import {
   Handshake,
   NK,
   KK,
+  NKpsk2,
   Transport,
   type Pattern,
 } from "../crypto/index.ts";
+import { pskFingerprint } from "./psk.ts";
 import type { Config } from "../crypto/index.ts";
 import { log, now, sinceMs, redactAuthQuery } from "../log.ts";
 
@@ -58,6 +60,11 @@ export function formatUpgradeRejection(status: number, body: string): string {
  *                                    anonymous, no registered key yet).
  *   - Only `client_public_key`    → client_pair       (KK; both sides
  *                                    are registered on the account).
+ *   - `noise_pattern: "NKpsk2"`   → self-hosted PSK pairing. Client
+ *                                    signaled `?psk_required=1` at
+ *                                    WS upgrade; daemon must hold the
+ *                                    matching PSK or it refuses to
+ *                                    handshake.
  *   - Neither                     → self-hosted paired (NK).
  */
 export interface PairedMeta {
@@ -68,6 +75,11 @@ export interface PairedMeta {
    *  Curve25519 Noise static via ed25519→curve25519 and feeds it into
    *  the KK handshake as `remoteStaticPublicKey`. Base64url. */
   client_public_key?: string;
+  /** Set by the relay when the client signaled `?psk_required=1` on
+   *  the WS upgrade. The daemon refuses to handshake unless it has a
+   *  matching PSK loaded. Self-hosted only — public-relay mode uses
+   *  the account auth model instead. */
+  noise_pattern?: "NKpsk2";
 }
 
 export interface RelayEvents {
@@ -94,6 +106,24 @@ export interface RelayEvents {
  * keypair (required for NK's responder pre-message and for KK's
  * `ss`/`es`/`se`).
  */
+/**
+ * Optional auth material a RelayConnection may carry. Today: a PSK for
+ * `Noise_NKpsk2`. The daemon loads this at startup from `--psk-file` /
+ * `PTY_RELAY_PSK` (see `src/relay/psk.ts`) and passes it to every
+ * per-client RelayConnection.
+ */
+export interface RelayAuth {
+  preSharedKey?: Uint8Array;
+  /** Optional callback invoked once per handshake outcome (success +
+   *  fail) when a PSK is in play. Lets the daemon emit a structured
+   *  audit log line per the design doc § "Audit logging". */
+  onPskAuthAttempt?: (event: {
+    outcome: "ok" | "fail";
+    fingerprint: string;
+    reason?: string;
+  }) => void;
+}
+
 export class RelayConnection {
   private ws: WebSocket | null = null;
   private transport: Transport | null = null;
@@ -101,13 +131,25 @@ export class RelayConnection {
   private config: Config;
   private wsUrlFactory: string | (() => string);
   private events: RelayEvents;
+  private auth: RelayAuth;
+  /** When the responder picked NKpsk2 in beginHandshake, this is the
+   *  PSK's fingerprint to log on success/failure. Cleared after
+   *  audit-emission so the success path doesn't double-log on a
+   *  subsequent reconnect. */
+  private pskAuthFingerprint: string | null = null;
   private state: "connecting" | "waiting" | "handshaking" | "ready" | "closed" =
     "connecting";
 
-  constructor(wsUrl: string | (() => string), config: Config, events: RelayEvents) {
+  constructor(
+    wsUrl: string | (() => string),
+    config: Config,
+    events: RelayEvents,
+    auth: RelayAuth = {},
+  ) {
     this.wsUrlFactory = wsUrl;
     this.config = config;
     this.events = events;
+    this.auth = auth;
   }
 
   connect(): void {
@@ -238,6 +280,8 @@ export class RelayConnection {
             typeof msg.pairing_hash_id === "string" ? msg.pairing_hash_id : undefined,
           client_public_key:
             typeof msg.client_public_key === "string" ? msg.client_public_key : undefined,
+          noise_pattern:
+            msg.noise_pattern === "NKpsk2" ? "NKpsk2" : undefined,
         };
         // beginHandshake is synchronous by design: both `state =
         // "handshaking"` and `this.handshake = ...` must be set before
@@ -284,6 +328,7 @@ export class RelayConnection {
   private beginHandshake(meta: PairedMeta): void {
     let pattern: Pattern;
     let remoteStaticPublicKey: Uint8Array | undefined;
+    let preSharedKey: Uint8Array | undefined;
 
     if (meta.client_public_key) {
       pattern = KK;
@@ -294,7 +339,30 @@ export class RelayConnection {
       // Synchronous: libsodium's Ed25519→Curve25519 is a pure call,
       // and `await sodium.ready` happened globally at daemon start.
       remoteStaticPublicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(edBytes);
+    } else if (meta.noise_pattern === "NKpsk2") {
+      // Client signaled `?psk_required=1` at the WS upgrade. Refuse
+      // if we don't actually have a PSK loaded — better a clean
+      // construction-time error here than a confusing AEAD failure
+      // two messages in.
+      if (!this.auth.preSharedKey) {
+        const reason =
+          "client requested NKpsk2 but this daemon has no PSK configured (start with --psk-file or PTY_RELAY_PSK)";
+        this.auth.onPskAuthAttempt?.({ outcome: "fail", fingerprint: "-", reason });
+        throw new Error(reason);
+      }
+      pattern = NKpsk2;
+      preSharedKey = this.auth.preSharedKey;
+      this.pskAuthFingerprint = pskFingerprint(preSharedKey);
     } else {
+      // Plain NK pairing. If we have a PSK loaded, refuse — operator
+      // explicitly enabled PSK auth and a non-PSK client shouldn't
+      // be able to slip past it.
+      if (this.auth.preSharedKey) {
+        const reason =
+          "daemon has PSK configured; refusing non-PSK pairing (client must pass `?psk_required=1`)";
+        this.auth.onPskAuthAttempt?.({ outcome: "fail", fingerprint: "-", reason });
+        throw new Error(reason);
+      }
       pattern = NK;
     }
 
@@ -310,6 +378,7 @@ export class RelayConnection {
         privateKey: this.config.secretKey,
       },
       remoteStaticPublicKey,
+      preSharedKey,
     });
     this.state = "handshaking";
     log("ws-pair", "handshake begin", { pattern: pattern.name });
@@ -330,9 +399,25 @@ export class RelayConnection {
         log("ws-pair", "handshake complete + welcome sent", {
           welcomeBytes: welcome.length,
         });
+        if (this.pskAuthFingerprint) {
+          this.auth.onPskAuthAttempt?.({
+            outcome: "ok",
+            fingerprint: this.pskAuthFingerprint,
+          });
+          this.pskAuthFingerprint = null;
+        }
         this.events.onHandshakeComplete(this.transport);
       } catch (err) {
-        log("ws-pair", "handshake failed", { error: (err as any)?.message ?? String(err) });
+        const message = (err as any)?.message ?? String(err);
+        log("ws-pair", "handshake failed", { error: message });
+        if (this.pskAuthFingerprint) {
+          this.auth.onPskAuthAttempt?.({
+            outcome: "fail",
+            fingerprint: this.pskAuthFingerprint,
+            reason: message,
+          });
+          this.pskAuthFingerprint = null;
+        }
         this.events.onError(
           err instanceof Error ? err : new Error(`Handshake failed: ${err}`)
         );

--- a/src/serve/pairing.ts
+++ b/src/serve/pairing.ts
@@ -5,6 +5,9 @@ import { log } from "../log.ts";
 export interface ClientEntry {
   client: WebSocket;
   daemon: WebSocket | null; // per-client daemon socket, null while waiting
+  /** Captured from `?psk_required=1` at WS upgrade. Echoed into the
+   *  `paired` frame so the daemon picks NKpsk2 instead of NK. */
+  pskRequired: boolean;
 }
 
 interface PrimaryEntry {
@@ -115,6 +118,7 @@ export class PairingRegistry {
       remoteAddr?: string | null;
       userAgent?: string | null;
       origin?: string | null;
+      pskRequired?: boolean;
     }
   ): string | null {
     const entry = this.entries.get(secretHash);
@@ -125,6 +129,7 @@ export class PairingRegistry {
     const clientEntry: ClientEntry = {
       client: ws,
       daemon: null,
+      pskRequired: !!meta?.pskRequired,
     };
 
     entry.clients.set(clientId, clientEntry);
@@ -137,6 +142,9 @@ export class PairingRegistry {
       };
       if (clientToken) {
         msg.client_token = clientToken;
+      }
+      if (clientEntry.pskRequired) {
+        msg.psk_required = true;
       }
       if (meta && (meta.remoteAddr || meta.userAgent || meta.origin)) {
         msg.meta = {
@@ -201,8 +209,14 @@ export class PairingRegistry {
 
     clientEntry.daemon = ws;
 
-    // Send paired to both sides
-    const paired = JSON.stringify({ type: "paired" });
+    // Send paired to both sides. When the client signaled
+    // `?psk_required=1` at the WS upgrade, propagate that into the
+    // metadata both peers see so they negotiate NKpsk2 in lockstep.
+    const pairedPayload: Record<string, unknown> = { type: "paired" };
+    if (clientEntry.pskRequired) {
+      pairedPayload.noise_pattern = "NKpsk2";
+    }
+    const paired = JSON.stringify(pairedPayload);
     try {
       clientEntry.client.send(paired);
     } catch {

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -181,11 +181,12 @@ export function createRelayServer(
       const origin =
         typeof originHeader === "string" ? originHeader : null;
 
+      const pskRequired = url.searchParams.get("psk_required") === "1";
       const id = registry.registerClient(
         secretHash,
         ws,
         clientToken ?? undefined,
-        { remoteAddr, userAgent, origin }
+        { remoteAddr, userAgent, origin, pskRequired }
       );
       log("pairing", "registerClient", {
         assigned: id,

--- a/src/terminal/client-connection.ts
+++ b/src/terminal/client-connection.ts
@@ -28,12 +28,17 @@ export interface ClientRelayEvents {
  * of a ping, the connection is terminated immediately.
  */
 /** Noise role configuration. NK only supplies the daemon pubkey; KK
- *  additionally supplies the client's own static keypair. */
+ *  additionally supplies the client's own static keypair; NKpsk2
+ *  additionally supplies a 32-byte pre-shared key. */
 export interface ClientNoise {
   pattern: Pattern;
   daemonPublicKey: Uint8Array;
-  /** Required for KK; must be omitted for NK. */
+  /** Required for KK; must be omitted for NK / NKpsk2. */
   clientStaticKeys?: { publicKey: Uint8Array; privateKey: Uint8Array };
+  /** Required when `pattern` is NKpsk2; must be omitted for NK / KK.
+   *  Loaded by the caller via `loadPsk()` from `--psk-file` or
+   *  `PTY_RELAY_PSK`. */
+  preSharedKey?: Uint8Array;
 }
 
 export class ClientRelayConnection {
@@ -258,6 +263,7 @@ export class ClientRelayConnection {
       initiator: true,
       remoteStaticPublicKey: this.noise.daemonPublicKey,
       staticKeys: this.noise.clientStaticKeys,
+      preSharedKey: this.noise.preSharedKey,
     });
     const hello = this.handshake.writeMessage();
     this.ws!.send(hello);

--- a/test/noise-psk.test.ts
+++ b/test/noise-psk.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import sodium from "libsodium-wrappers-sumo";
+import {
+  ready,
+  generateKeypair,
+  Handshake,
+  NK,
+  NKpsk2,
+  PSK_LEN,
+  Transport,
+} from "../src/crypto/index.ts";
+
+beforeAll(async () => {
+  await ready();
+});
+
+/** Run one complete two-message handshake between matched parties and
+ *  return their HandshakeResults. */
+function runHandshake(initiator: Handshake, responder: Handshake) {
+  const hello = initiator.writeMessage();
+  responder.readMessage(hello);
+  const welcome = responder.writeMessage();
+  initiator.readMessage(welcome);
+  return { i: initiator.split(), r: responder.split() };
+}
+
+function randomPsk(): Uint8Array {
+  return sodium.randombytes_buf(PSK_LEN);
+}
+
+describe("Noise NKpsk2 handshake — happy path", () => {
+  it("both sides compute the same transport keys when the PSK matches", () => {
+    const daemon = generateKeypair();
+    const psk = randomPsk();
+    const i = new Handshake({
+      pattern: NKpsk2,
+      initiator: true,
+      remoteStaticPublicKey: daemon.publicKey,
+      preSharedKey: psk,
+    });
+    const r = new Handshake({
+      pattern: NKpsk2,
+      initiator: false,
+      staticKeys: { publicKey: daemon.publicKey, privateKey: daemon.secretKey },
+      preSharedKey: psk,
+    });
+    const { i: iKeys, r: rKeys } = runHandshake(i, r);
+
+    // initiator-send must equal responder-recv (and vice versa) for
+    // bidirectional transport.
+    const it_ = new Transport(iKeys);
+    const rt_ = new Transport(rKeys);
+    const msg1 = it_.encrypt(new TextEncoder().encode("hello"));
+    expect(new TextDecoder().decode(rt_.decrypt(msg1))).toBe("hello");
+    const msg2 = rt_.encrypt(new TextEncoder().encode("world"));
+    expect(new TextDecoder().decode(it_.decrypt(msg2))).toBe("world");
+  });
+
+  it("split() runs both directions with a different psk per handshake (no key reuse across sessions)", () => {
+    const daemon = generateKeypair();
+    const make = (psk: Uint8Array) => {
+      const ini = new Handshake({
+        pattern: NKpsk2,
+        initiator: true,
+        remoteStaticPublicKey: daemon.publicKey,
+        preSharedKey: psk,
+      });
+      const res = new Handshake({
+        pattern: NKpsk2,
+        initiator: false,
+        staticKeys: { publicKey: daemon.publicKey, privateKey: daemon.secretKey },
+        preSharedKey: psk,
+      });
+      return runHandshake(ini, res);
+    };
+
+    const a = make(randomPsk());
+    const b = make(randomPsk());
+
+    // Same plaintext encrypted under independent transports must
+    // produce distinct ciphertexts.
+    const ta = new Transport(a.i);
+    const tb = new Transport(b.i);
+    const ca = ta.encrypt(new TextEncoder().encode("x"));
+    const cb = tb.encrypt(new TextEncoder().encode("x"));
+    expect(Array.from(ca)).not.toEqual(Array.from(cb));
+  });
+});
+
+describe("Noise NKpsk2 handshake — auth failures", () => {
+  it("responder rejects the initiator when the PSK doesn't match", () => {
+    const daemon = generateKeypair();
+    const i = new Handshake({
+      pattern: NKpsk2,
+      initiator: true,
+      remoteStaticPublicKey: daemon.publicKey,
+      preSharedKey: randomPsk(),
+    });
+    const r = new Handshake({
+      pattern: NKpsk2,
+      initiator: false,
+      staticKeys: { publicKey: daemon.publicKey, privateKey: daemon.secretKey },
+      preSharedKey: randomPsk(), // different PSK
+    });
+
+    // First message uses only `e, es` — has not consumed the PSK yet
+    // on either side, so the first read succeeds.
+    const hello = i.writeMessage();
+    r.readMessage(hello);
+
+    // Responder's second message mixes its (different) PSK after `ee`
+    // — initiator can't decrypt it.
+    const welcome = r.writeMessage();
+    expect(() => i.readMessage(welcome)).toThrow();
+  });
+
+  it("responder rejects the initiator when the PSK is right size but wrong bytes (off by one)", () => {
+    const daemon = generateKeypair();
+    const correct = randomPsk();
+    const tampered = new Uint8Array(correct);
+    tampered[0] ^= 0x01;
+
+    const i = new Handshake({
+      pattern: NKpsk2,
+      initiator: true,
+      remoteStaticPublicKey: daemon.publicKey,
+      preSharedKey: correct,
+    });
+    const r = new Handshake({
+      pattern: NKpsk2,
+      initiator: false,
+      staticKeys: { publicKey: daemon.publicKey, privateKey: daemon.secretKey },
+      preSharedKey: tampered,
+    });
+
+    const hello = i.writeMessage();
+    r.readMessage(hello);
+    const welcome = r.writeMessage();
+    expect(() => i.readMessage(welcome)).toThrow();
+  });
+
+  it("a v1-NK client cannot interop with an NKpsk2 responder — the protocol-name differs so even message 1 fails", () => {
+    const daemon = generateKeypair();
+    const i = new Handshake({
+      pattern: NK,
+      initiator: true,
+      remoteStaticPublicKey: daemon.publicKey,
+    });
+    const r = new Handshake({
+      pattern: NKpsk2,
+      initiator: false,
+      staticKeys: { publicKey: daemon.publicKey, privateKey: daemon.secretKey },
+      preSharedKey: randomPsk(),
+    });
+
+    const hello = i.writeMessage();
+    // NK and NKpsk2 use different protocol names ("Noise_NK_…" vs
+    // "Noise_NKpsk2_…"), which seed different initial SymmetricState
+    // hashes. The chaining + cipher keys diverge from message 1's
+    // encryptAndHash, so the responder can't decrypt the initiator's
+    // first message at all. Defense by construction: no chance for a
+    // v1 client to slip past a v2-only daemon.
+    expect(() => r.readMessage(hello)).toThrow();
+  });
+});
+
+describe("Noise NKpsk2 handshake — input validation", () => {
+  it("throws at construction if a psk-pattern is used without a preSharedKey", () => {
+    const daemon = generateKeypair();
+    expect(
+      () =>
+        new Handshake({
+          pattern: NKpsk2,
+          initiator: true,
+          remoteStaticPublicKey: daemon.publicKey,
+        }),
+    ).toThrow(/pass preSharedKey/);
+  });
+
+  it("throws at construction if the PSK is too short", () => {
+    const daemon = generateKeypair();
+    expect(
+      () =>
+        new Handshake({
+          pattern: NKpsk2,
+          initiator: true,
+          remoteStaticPublicKey: daemon.publicKey,
+          preSharedKey: new Uint8Array(31),
+        }),
+    ).toThrow(/exactly 32/);
+  });
+
+  it("throws at construction if the PSK is too long", () => {
+    const daemon = generateKeypair();
+    expect(
+      () =>
+        new Handshake({
+          pattern: NKpsk2,
+          initiator: true,
+          remoteStaticPublicKey: daemon.publicKey,
+          preSharedKey: new Uint8Array(33),
+        }),
+    ).toThrow(/exactly 32/);
+  });
+
+  it("throws at construction if a non-psk pattern is given a preSharedKey (defense against caller misconfiguration)", () => {
+    const daemon = generateKeypair();
+    expect(
+      () =>
+        new Handshake({
+          pattern: NK,
+          initiator: true,
+          remoteStaticPublicKey: daemon.publicKey,
+          preSharedKey: randomPsk(),
+        }),
+    ).toThrow(/no "psk" token/);
+  });
+});
+
+describe("Noise NKpsk2 — protocol name", () => {
+  it("matches the spec-canonical Noise_NKpsk2_25519_ChaChaPoly_BLAKE2b string", () => {
+    expect(NKpsk2.name).toBe("Noise_NKpsk2_25519_ChaChaPoly_BLAKE2b");
+  });
+
+  it("has the psk token in the second message (not the first — that would be psk0)", () => {
+    expect(NKpsk2.messages[0]).toEqual(["e", "es"]);
+    expect(NKpsk2.messages[1]).toEqual(["e", "ee", "psk"]);
+  });
+});
+
+describe("PSK_LEN constant", () => {
+  it("is 32 bytes per Noise spec § 9", () => {
+    expect(PSK_LEN).toBe(32);
+  });
+});

--- a/test/psk-loader.test.ts
+++ b/test/psk-loader.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import sodium from "libsodium-wrappers-sumo";
+import {
+  loadPsk,
+  generatePsk,
+  pskFingerprint,
+} from "../src/relay/psk.ts";
+import { PSK_LEN, ready } from "../src/crypto/index.ts";
+
+beforeAll(async () => {
+  await ready();
+});
+
+let dir: string;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+let stderrBytes: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "psk-loader-"));
+  stderrBytes = "";
+  stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: string | Uint8Array) => {
+      stderrBytes += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+      return true;
+    });
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+function writePskFile(name: string, contents: string, mode = 0o600): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, contents, { mode });
+  return p;
+}
+
+describe("generatePsk", () => {
+  it("produces a 43-char URL-safe-base64-no-padding string", () => {
+    const psk = generatePsk();
+    expect(psk.length).toBe(43);
+    expect(psk).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("decodes back to exactly PSK_LEN bytes", () => {
+    const psk = generatePsk();
+    const bytes = sodium.from_base64(psk, sodium.base64_variants.URLSAFE_NO_PADDING);
+    expect(bytes.length).toBe(PSK_LEN);
+  });
+
+  it("generates a different value each call (sanity check on RNG)", () => {
+    const a = generatePsk();
+    const b = generatePsk();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("pskFingerprint", () => {
+  it("returns a stable 16-char string for the same PSK", () => {
+    const bytes = sodium.randombytes_buf(PSK_LEN);
+    const a = pskFingerprint(bytes);
+    const b = pskFingerprint(bytes);
+    expect(a).toBe(b);
+    expect(a.length).toBe(16);
+  });
+
+  it("differs for different PSKs", () => {
+    const a = pskFingerprint(sodium.randombytes_buf(PSK_LEN));
+    const b = pskFingerprint(sodium.randombytes_buf(PSK_LEN));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("loadPsk — resolution order", () => {
+  it("returns null when neither --psk-file nor PTY_RELAY_PSK is set", async () => {
+    const result = await loadPsk({ envVar: null });
+    expect(result).toBeNull();
+  });
+
+  it("prefers --psk-file over PTY_RELAY_PSK", async () => {
+    const filePsk = generatePsk();
+    const envPsk = generatePsk();
+    const p = writePskFile("psk", filePsk);
+    const result = await loadPsk({ pskFile: p, envVar: envPsk });
+    expect(result).not.toBeNull();
+    // Compare via fingerprint — easier than asserting array equality.
+    expect(pskFingerprint(result!)).toBe(
+      pskFingerprint(
+        sodium.from_base64(filePsk, sodium.base64_variants.URLSAFE_NO_PADDING),
+      ),
+    );
+  });
+
+  it("falls back to PTY_RELAY_PSK when --psk-file is absent", async () => {
+    const envPsk = generatePsk();
+    const result = await loadPsk({ envVar: envPsk });
+    expect(result).not.toBeNull();
+    expect(pskFingerprint(result!)).toBe(
+      pskFingerprint(
+        sodium.from_base64(envPsk, sodium.base64_variants.URLSAFE_NO_PADDING),
+      ),
+    );
+  });
+
+  it("treats empty env var as not-configured", async () => {
+    const result = await loadPsk({ envVar: "" });
+    expect(result).toBeNull();
+  });
+});
+
+describe("loadPsk — format validation", () => {
+  it("trims a trailing newline in the file", async () => {
+    const psk = generatePsk();
+    const p = writePskFile("psk", psk + "\n");
+    const result = await loadPsk({ pskFile: p, envVar: null });
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(PSK_LEN);
+  });
+
+  it("trims surrounding whitespace", async () => {
+    const psk = generatePsk();
+    const p = writePskFile("psk", `  ${psk}  \n`);
+    const result = await loadPsk({ pskFile: p, envVar: null });
+    expect(result).not.toBeNull();
+  });
+
+  it("rejects an empty PSK", async () => {
+    const p = writePskFile("psk", "");
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /PSK is empty/,
+    );
+  });
+
+  it("rejects a whitespace-only PSK", async () => {
+    const p = writePskFile("psk", "   \n");
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /PSK is empty/,
+    );
+  });
+
+  it("rejects embedded whitespace (multi-line / mangled paste)", async () => {
+    const p = writePskFile("psk", "abc def\n");
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /contains whitespace/,
+    );
+  });
+
+  it("rejects non-base64url content", async () => {
+    const p = writePskFile("psk", "not_base64_$$$\n");
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /valid URL-safe-base64-no-padding/,
+    );
+  });
+
+  it("rejects a too-short PSK (decoded < 32 bytes)", async () => {
+    // 8 random bytes → ~11-char b64.
+    const short = sodium.to_base64(
+      sodium.randombytes_buf(8),
+      sodium.base64_variants.URLSAFE_NO_PADDING,
+    );
+    const p = writePskFile("psk", short);
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /must be exactly 32/,
+    );
+  });
+
+  it("rejects a too-long PSK (decoded > 32 bytes)", async () => {
+    const long = sodium.to_base64(
+      sodium.randombytes_buf(64),
+      sodium.base64_variants.URLSAFE_NO_PADDING,
+    );
+    const p = writePskFile("psk", long);
+    await expect(loadPsk({ pskFile: p, envVar: null })).rejects.toThrow(
+      /must be exactly 32/,
+    );
+  });
+
+  it("rejects a PSK file that doesn't exist", async () => {
+    await expect(
+      loadPsk({ pskFile: path.join(dir, "nope"), envVar: null }),
+    ).rejects.toThrow(/cannot read/);
+  });
+
+  it("rejects env PSK with bad format too", async () => {
+    await expect(
+      loadPsk({ envVar: "not_base64_$$$" }),
+    ).rejects.toThrow(/valid URL-safe-base64-no-padding/);
+  });
+});
+
+describe("loadPsk — file mode warning", () => {
+  it("warns to stderr when the PSK file is world-readable (mode 0644)", async () => {
+    const psk = generatePsk();
+    const p = writePskFile("psk", psk, 0o644);
+    await loadPsk({ pskFile: p, envVar: null });
+    expect(stderrBytes).toMatch(/readable by group\/other/);
+    expect(stderrBytes).toContain(p);
+  });
+
+  it("does NOT warn when the file is mode 0600", async () => {
+    const psk = generatePsk();
+    const p = writePskFile("psk", psk, 0o600);
+    await loadPsk({ pskFile: p, envVar: null });
+    expect(stderrBytes).toBe("");
+  });
+
+  it("the warning is informational — load still succeeds", async () => {
+    const psk = generatePsk();
+    const p = writePskFile("psk", psk, 0o644);
+    const result = await loadPsk({ pskFile: p, envVar: null });
+    expect(result).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements brief-006 PSK authentication on top of the merged design (PR #21). When the operator passes `--psk-file` to both `local start` and `connect`, every per-client connection uses `Noise_NKpsk2` and a daemon with a PSK loaded refuses plain-NK clients. When no PSK is configured, behavior is unchanged.

## What's in this PR

- **Phase 1** (e0e719f) — `Noise_NKpsk2` pattern + `psk` token + `mixKeyAndHash` in the engine; 12 unit tests covering happy-path, mismatched PSK, tampered PSK, protocol-name divergence, construction-time validation.
- **Phase 2** (dd30a04) — `src/relay/psk.ts` loader: `--psk-file` / `PTY_RELAY_PSK` resolution, 43-char URL-safe-base64 format validation, world-readable file warning, `generatePsk()` + `pskFingerprint()`. 22 unit tests.
- **Phase 3** (ad51187) — server-side wiring: pairing.ts propagates `?psk_required=1` into the `paired` frame as `noise_pattern: \"NKpsk2\"`; start.ts loads the PSK once and attaches an audit callback that emits one structured `psk-auth attempt` line per handshake outcome; RelayConnection.beginHandshake dispatches NK vs NKpsk2 and refuses asymmetric pairings on either side.
- **Phase 4** (ad51187) — client-side wiring: `ClientNoise` carries the PSK; `connect.ts` picks NKpsk2 when loaded, appends `&psk_required=1` to the WS URL, and plumbs the auth material through `attachSession` / `attemptConnect` / `connectWithReconnect` / `fetchSessions` so reconnects use the same material. `connectEmbedded` mirrors.
- **Phase 5** (ad51187) — `pty-relay psk-gen` subcommand prints a fresh PSK in the documented format; `integration/psk-auth.test.ts` drives the three matrix cells end-to-end (matching PSK both sides → echo round-trip; server-only PSK → rejection; client-only PSK → rejection).

## Design decisions

All five Nathan-routed PSK design questions are answered per PR #21:

1. **KDF shape** — raw 32-byte PSK (no Argon2id), generated via `psk-gen`.
2. **`psk-gen`** — yes, shipped.
3. **Rotation** — restart-to-rotate; no SIGHUP.
4. **Public-relay** — self-hosted (`local start`) only; not surfaced on `server start`.
5. **Audit log** — structured INFO line per handshake outcome via `log(\"psk-auth\", \"attempt\", ...)` + a stderr `[psk-auth] client X REJECTED — reason` warn on fail. No IP-blocklist.

## Test plan

- [x] Unit: 746/746 green (12 new in `noise-psk.test.ts`, 22 new in `psk-loader.test.ts`)
- [x] Integration: 76/76 green (3 new in `psk-auth.test.ts`)
- [x] Manual: `pty-relay psk-gen` produces a 43-char base64url string that round-trips through `loadPsk` to exactly 32 bytes (verified via the unit test that exercises the same CLI surface)
- [x] PSK file mode warning fires at 0o644, stays silent at 0o600

## Backwards compatibility

None broken — PSK is purely additive. Daemons without `--psk-file` behave exactly as before. Clients without `--psk-file` connecting to a daemon without `--psk-file` use plain `Noise_NK` exactly as before.

## Not in this PR

- The two `it.skip` revoked-token e2e tests remain skipped — investigation overturned the original \"stderr drain\" hypothesis; root cause is upstream of the client (relay never forwards or WS upgrade silently hangs). Tracked separately.
- PR #21 (the design doc) is a separate, DRAFT-permanent PR per Nathan's call — it stays as the spec reference.

cc @cos