### PR TITLE
fix(tests): reap leaked pty daemons at vitest teardown

### DIFF
--- a/integration/e2e.test.ts
+++ b/integration/e2e.test.ts
@@ -191,7 +191,7 @@ describe("spawn via self-hosted relay", () => {
 
     // Remote-spawn cwd is constrained to $HOME. Point the daemon's HOME at
     // a temp dir so the test can place a real subdirectory under it.
-    const fakeHome = fs.mkdtempSync(path.join("/tmp", "home-cwd-"));
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "home-cwd-"));
     const targetDir = path.join(fakeHome, "workdir");
     fs.mkdirSync(targetDir);
 
@@ -1489,7 +1489,7 @@ describe("credentials at rest", () => {
  */
 async function probeKeychainForE2E(): Promise<boolean> {
   const { KeychainStore } = await import("../src/storage/keychain-store.ts");
-  const probeDir = fs.mkdtempSync(path.join("/tmp", "e2e-kc-probe-"));
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-kc-probe-"));
   try {
     const store = await KeychainStore.tryOpen(probeDir);
     if (!store) return false;
@@ -1809,7 +1809,7 @@ describe("reset command", () => {
  */
 const keychainResetAvailable = await (async () => {
   const { KeychainStore } = await import("../src/storage/keychain-store.ts");
-  const probeDir = fs.mkdtempSync(path.join("/tmp", "reset-kc-probe-"));
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), "reset-kc-probe-"));
   try {
     const store = await KeychainStore.tryOpen(probeDir);
     if (!store) return false;

--- a/integration/helpers/index.ts
+++ b/integration/helpers/index.ts
@@ -33,9 +33,10 @@ export interface TestContext {
 }
 
 export function createTestContext(): TestContext {
-  // Use /tmp directly instead of os.tmpdir() because macOS resolves tmpdir
-  // to /var/folders/... which is too long for Unix socket paths (104 char limit).
-  const stateDir = fs.mkdtempSync(path.join("/tmp", "pty-integ-"));
+  // Rely on os.tmpdir() — vitest globalSetup sets TMPDIR to /tmp/pv-XXX so
+  // socket paths stay short (macOS's raw /var/folders tmpdir would exceed
+  // AF_UNIX's 103-byte limit for daemon.sock nested underneath).
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "pty-integ-"));
   return { stateDir, cleanup: [] };
 }
 

--- a/integration/security.test.ts
+++ b/integration/security.test.ts
@@ -12,6 +12,7 @@ import {
 import { getSession } from "@myobie/pty/client";
 import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 let ctx: TestContext;
@@ -131,7 +132,7 @@ describe("remote spawn default shape", () => {
     const relayConfigDir = path.join(ctx.stateDir, "relay");
     // Pin HOME + SHELL on the server side so we can assert on what the
     // daemon chose; in real usage these come from the operator's env.
-    const fakeHome = fs.mkdtempSync(path.join("/tmp", "home-spawn-"));
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "home-spawn-"));
     const { baseToken } = await startServerWithSpawn(relayConfigDir, port, {
       HOME: fakeHome,
       SHELL: "/bin/bash",
@@ -220,7 +221,7 @@ describe("spawn cwd containment to $HOME", () => {
     const relayConfigDir = path.join(ctx.stateDir, "relay");
 
     // Put HOME somewhere specific so /etc is unambiguously outside it.
-    const fakeHome = fs.mkdtempSync(path.join("/tmp", "home-"));
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "home-"));
     const { baseToken } = await startServerWithSpawn(relayConfigDir, port, {
       HOME: fakeHome,
     });
@@ -259,7 +260,7 @@ describe("spawn cwd containment to $HOME", () => {
     const port = getPort();
     const relayConfigDir = path.join(ctx.stateDir, "relay");
 
-    const fakeHome = fs.mkdtempSync(path.join("/tmp", "home-ok-"));
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "home-ok-"));
     const subDir = path.join(fakeHome, "work");
     fs.mkdirSync(subDir);
     const { baseToken } = await startServerWithSpawn(relayConfigDir, port, {

--- a/integration/setup.ts
+++ b/integration/setup.ts
@@ -8,6 +8,7 @@
  * src/storage/bootstrap.test.ts, which properly clean up after themselves.
  */
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 process.env.PTY_RELAY_KDF_PROFILE = "interactive";
@@ -17,5 +18,5 @@ process.env.PTY_RELAY_BACKEND = "passphrase";
 // Safety net: if a test forgets to override PTY_SESSION_DIR in beforeEach,
 // don't fall back to the developer's real ~/.local/state/pty directory.
 if (!process.env.PTY_SESSION_DIR) {
-  process.env.PTY_SESSION_DIR = fs.mkdtempSync(path.join("/tmp", "pty-integ-fallback-"));
+  process.env.PTY_SESSION_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "pty-integ-fallback-"));
 }

--- a/integration/vitest.config.ts
+++ b/integration/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
     include: ["integration/**/*.test.ts"],
     exclude: ["**/*.spec.ts", "node_modules/**"],
     setupFiles: ["./integration/setup.ts"],
+    globalSetup: ["./test/setup/vitest-global.ts"],
   },
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,6 +5,7 @@
  * profile (~50ms) across the test suite so the storage stack stays fast.
  */
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 process.env.PTY_RELAY_KDF_PROFILE = "interactive";
@@ -20,5 +21,5 @@ if (!process.env.PTY_RELAY_PASSPHRASE) {
 // directory. Without this, any test that reaches the pty daemon/client would
 // read/write the user's actual session state under ~/.local/state/pty.
 if (!process.env.PTY_SESSION_DIR) {
-  process.env.PTY_SESSION_DIR = fs.mkdtempSync(path.join("/tmp", "pty-relay-unit-"));
+  process.env.PTY_SESSION_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "pty-relay-unit-"));
 }

--- a/test/setup/vitest-global.ts
+++ b/test/setup/vitest-global.ts
@@ -1,0 +1,141 @@
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Vitest globalSetup/globalTeardown — reaps leaked pty daemons.
+ *
+ * Integration tests spawn detached pty daemons (that's how `pty attach`
+ * survives a client crash by design). When vitest exits, any daemon still
+ * running is reparented to init and its tmpdir + open ttys leak. Over days
+ * of test runs this accumulates until the machine's ttys/socket ceiling is
+ * hit and `posix_spawnp` starts failing everywhere.
+ *
+ * Fix: point TMPDIR at a per-run root under /tmp; at teardown, find every
+ * pid holding a file or unix socket under that root and SIGTERM→SIGKILL
+ * them, then rm the tree.
+ *
+ * Mirrors pty PR #52 (fix/vitest-globalTeardown-reap-daemons) — same file
+ * layout, same env-var name (PTY_VITEST_RUN_ROOT), same TMPDIR-override
+ * approach, same kill cascade — with one deliberate divergence: we union
+ * `lsof +D` (regular files under root) with `lsof -U` (unix sockets whose
+ * bound path is under root). `+D` on macOS doesn't index socket-name
+ * entries in its directory walk, so a daemon that holds ONLY its listen
+ * socket — which describes the pty daemon exactly — is invisible to
+ * `+D` alone. See pty-relay commit message for the reproducer.
+ *
+ * `/tmp` (not `os.tmpdir()`) as the base: macOS resolves `os.tmpdir()` to
+ * `/var/folders/<hash>/T/`, and nested socket paths exceed AF_UNIX's
+ * 103-byte limit → `EINVAL: listen`. `/tmp/pv-XXXXXX` stays comfortably
+ * under.
+ */
+
+let runRoot: string | undefined;
+
+function shortBaseTmp(): string {
+  return process.platform === "win32" ? os.tmpdir() : "/tmp";
+}
+
+export async function setup(): Promise<void> {
+  runRoot = fs.mkdtempSync(path.join(shortBaseTmp(), `pv-`));
+  process.env.PTY_VITEST_RUN_ROOT = runRoot;
+  process.env.TMPDIR = runRoot;
+  process.stderr.write(`[vitest-global] runRoot=${runRoot}\n`);
+}
+
+/** Collect pids from an lsof `-Fpn` stream whose `n` line starts under
+ *  either the given root or its /private/-prefixed twin (macOS's real
+ *  /tmp). Skips our own pid and pid 1. */
+function collectPidsUnderRoot(lsofOut: string, root: string, into: Set<number>): void {
+  const roots = [root + "/", `/private${root}/`];
+  let currentPid: number | null = null;
+  for (const line of lsofOut.split("\n")) {
+    if (line.startsWith("p")) {
+      const n = Number(line.slice(1));
+      currentPid = Number.isFinite(n) ? n : null;
+    } else if (line.startsWith("n") && currentPid !== null) {
+      const name = line.slice(1);
+      if (roots.some((r) => name.startsWith(r))) {
+        if (currentPid !== process.pid && currentPid > 1) into.add(currentPid);
+      }
+    }
+  }
+}
+
+export async function teardown(): Promise<void> {
+  if (!runRoot) return;
+  const root = runRoot;
+
+  const pids = new Set<number>();
+
+  // Regular files under root — daemon state / JSONL logs / etc.
+  try {
+    const out = execSync(`lsof -Fpn +D "${root}" 2>/dev/null || true`, {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    // `+D` output has no `n` line for the daemon socket, but the `+D`
+    // walk itself is scoped to root, so every `pN` block is a hit.
+    for (const line of out.split("\n")) {
+      if (line.startsWith("p")) {
+        const n = Number(line.slice(1));
+        if (Number.isFinite(n) && n !== process.pid && n > 1) pids.add(n);
+      }
+    }
+  } catch {
+    // lsof may exit non-zero when no matches — treat as empty.
+  }
+
+  // Unix sockets whose bound path is under root — the pty daemon's
+  // listen socket is often the ONLY file it keeps open, so `+D` above
+  // misses it and we need this second sweep.
+  try {
+    const out = execSync(`lsof -Fpn -U 2>/dev/null || true`, {
+      encoding: "utf8",
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    collectPidsUnderRoot(out, root, pids);
+  } catch {
+    // ignore
+  }
+
+  const pidArr = Array.from(pids);
+  if (pidArr.length > 0) {
+    process.stderr.write(`[vitest-global] SIGTERM ${pidArr.length} leaked pids\n`);
+    for (const pid of pidArr) {
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+    const survivors: number[] = [];
+    for (const pid of pidArr) {
+      try {
+        process.kill(pid, 0);
+        survivors.push(pid);
+      } catch {
+        // exited
+      }
+    }
+    if (survivors.length > 0) {
+      process.stderr.write(`[vitest-global] SIGKILL ${survivors.length} survivors\n`);
+      for (const pid of survivors) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // gone between poll and kill
+        }
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  try {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 3 });
+  } catch {
+    // best-effort; something inside may still be busy briefly
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     globals: true,
     exclude: ["integration/**", "node_modules/**"],
     setupFiles: ["./test/setup.ts"],
+    globalSetup: ["./test/setup/vitest-global.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Mirrors [myobie/pty#52](https://github.com/myobie/pty/pull/52) — reaps orphan pty daemons that leak out of every vitest run and slowly exhaust the machine's ttys/socket ceiling.

Adds `test/setup/vitest-global.ts` and wires it as `globalSetup` in both `vitest.config.ts` and `integration/vitest.config.ts`.

- `setup()` mkdtemps `/tmp/pv-XXXXXX`, exports it as `PTY_VITEST_RUN_ROOT` and sets `TMPDIR`. Every test worker's `os.tmpdir()` then resolves inside the run root, so every `mkdtempSync(os.tmpdir(), ...)` in the tree lands there — the "zero-file-migration" pattern from pty PR #52's addendum.
- `teardown()` enumerates pids holding files / sockets under the run root, SIGTERMs, waits 2s, SIGKILLs survivors, then rms the tree.

Also migrates 8 sites that hardcoded `/tmp` (originally for AF_UNIX 103-byte socket path reasons on macOS) to `os.tmpdir()` so they get captured by the TMPDIR override. The 103-byte concern is handled centrally by keeping the run-root base short (`/tmp/pv-XXXXXX`).

## Deliberate divergence from pty PR #52

`lsof +D <dir>` on macOS walks the directory tree and lists processes holding regular files under it — but does NOT index unix-socket-name entries the same way. A process holding ONLY a listen socket inside `<dir>` is invisible to `+D` alone.

Reproducer (~30s):

```sh
mkdir -p /tmp/probe/x
node -e '
  const s = require(\"net\").createServer();
  s.listen(\"/tmp/probe/x/leak.sock\", () => setInterval(() => {}, 1e9));
' &
sleep 1
lsof -Fpn +D /tmp/probe            # → empty (misses the socket-only holder)
lsof -Fpn -U | grep /tmp/probe     # → finds it
```

The pty daemon (`@myobie/pty/dist/server.js`) fits that shape exactly — it holds only its listen socket, no persistent state fds. My first integration run using `+D`-only had teardown report 0 pids to reap while 8 daemons kept running with dead sockets in-hand.

So teardown runs both:

- `lsof -Fpn +D "$root"` — regular files (state, JSONL logs)
- `lsof -Fpn -U` filtered where the `n` line starts with `$root/` or `/private$root/` (macOS's /tmp symlink twin)

Pids from both sweeps are unioned before the SIGTERM cascade.

## Verification

Baseline `ps -Ao pid,command | grep 'dist/server.js' | wc -l` before + after both:

- `npm test` (69 files, 768 tests, all pass): 11 → 11
- `npm run test:integration` (9 files, 86 tests + 2 skips, all pass): 11 → 11

Teardown log for the integration run:

```
[vitest-global] runRoot=/tmp/pv-FKzWwW
[vitest-global] SIGTERM 8 leaked pids
```

No SIGKILL survivors — all 8 leaks cleanly reaped by SIGTERM.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` → all 768 unit tests pass, daemon count unchanged
- [x] `npm run test:integration` → all 86 integration tests pass, 8 leaks reaped, daemon count unchanged
- [ ] Reviewer to confirm the `+D` union with `-U` reads cleanly and the runRoot filter's `/private/` prefix twin is understood