### PR TITLE
fix(connect): accept ssh://user@host[:port]/session-name URLs

### DIFF
--- a/integration/peers-file.test.ts
+++ b/integration/peers-file.test.ts
@@ -274,4 +274,60 @@ describe("phase-2 ssh wiring — every subcommand routes through ssh", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("needs --session");
   });
+
+  // Fix B: ssh://user@host/session URLs. The pty TUI's attach-remote
+  // path hands us a URL of this shape (Nathan reported the "No known
+  // host" bug); the "URL is a complete address" mental model has to
+  // work from either side of the seam.
+  describe("ssh:// URL with session in the path", () => {
+    it("connect ssh://me@web1/work attaches by URL, resolved by authority", () => {
+      clearCallLog();
+      const result = runCli([
+        "connect",
+        "--config-dir",
+        configDir,
+        "ssh://me@web1/work",
+      ]);
+      expect(result.status).toBe(0);
+      expect(readCallLog()).toContain("me@web1 pty attach work");
+    });
+
+    it("connect ssh://me@web1 with no session errors helpfully", () => {
+      clearCallLog();
+      const result = runCli([
+        "connect",
+        "--config-dir",
+        configDir,
+        "ssh://me@web1",
+      ]);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("needs a session name");
+    });
+
+    it("session in the URL AND --session is ambiguous", () => {
+      clearCallLog();
+      const result = runCli([
+        "connect",
+        "--config-dir",
+        configDir,
+        "ssh://me@web1/work",
+        "--session",
+        "other",
+      ]);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Ambiguous");
+    });
+
+    it("unregistered authority errors instead of falling through to a stale label branch", () => {
+      clearCallLog();
+      const result = runCli([
+        "connect",
+        "--config-dir",
+        configDir,
+        "ssh://unknown@nowhere/work",
+      ]);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("No known ssh peer");
+    });
+  });
 });

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -14,7 +14,11 @@ import type { ParsedToken } from "../crypto/index.ts";
 import { ClientRelayConnection } from "../terminal/client-connection.ts";
 import { Terminal } from "../terminal/terminal.ts";
 import { ChannelConnection } from "../relay/channel-connection.ts";
-import { saveKnownHost } from "../relay/known-hosts.ts";
+import {
+  loadAllKnownHosts,
+  isSshHost,
+  saveKnownHost,
+} from "../relay/known-hosts.ts";
 import { loadPsk } from "../relay/psk.ts";
 import type { SecretStore } from "../storage/secret-store.ts";
 import { openSecretStore } from "../storage/bootstrap.ts";
@@ -52,18 +56,91 @@ export async function connect(
 ): Promise<void> {
   await ready();
   log("cli", "connect begin", {
-    target: looksLikeTokenUrl(tokenUrlOrLabel) ? "token-url" : tokenUrlOrLabel,
+    target: looksLikeTokenUrl(tokenUrlOrLabel)
+      ? "token-url"
+      : tokenUrlOrLabel.startsWith("ssh://")
+        ? "ssh-url"
+        : tokenUrlOrLabel,
     spawn: options?.spawn,
     cwd: options?.cwd,
     session: options?.session,
     hasTags: !!(options?.tags && Object.keys(options.tags).length > 0),
   });
 
-  // Dispatch: a raw http(s):// URL is a self-hosted token URL and goes
-  // through the existing flow. Anything else is treated as a known-hosts
-  // label — we look it up and, if public-mode, hand off to the public
-  // attach path. Labels are a recent addition for public-relay; the
-  // self-hosted UX still keys on paste-in token URLs.
+  // Dispatch order:
+  //   ssh://…                → resolve to a known ssh peer by authority
+  //                            (userHost + port), pick session from the
+  //                            URL path or from --session/--spawn
+  //   http(s)://…            → self-hosted token URL (existing flow)
+  //   anything else          → known-hosts label lookup (public / self /
+  //                            ssh via resolveHost)
+  if (tokenUrlOrLabel.startsWith("ssh://")) {
+    const { store, passphrase } = await openSecretStore(options?.configDir, {
+      interactive: true,
+      passphraseFile: options?.passphraseFile,
+    });
+    if (passphrase && !process.env.PTY_RELAY_PASSPHRASE) {
+      process.env.PTY_RELAY_PASSPHRASE = passphrase;
+    }
+    const { splitSshUrlAndSession, parseSshUrl, attachSshRemoteSession } =
+      await import("../relay/transport-ssh.ts");
+
+    let authorityUrl: string;
+    let urlSession: string | undefined;
+    try {
+      ({ authorityUrl, session: urlSession } =
+        splitSshUrlAndSession(tokenUrlOrLabel));
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
+
+    // Reject an ambiguous invocation where the caller supplied the
+    // session in TWO places. Mirrors how token URLs handle a session
+    // in the fragment + a --session flag.
+    const flagSession = options?.spawn ?? options?.session;
+    if (urlSession && flagSession) {
+      console.error(
+        `Ambiguous: session "${urlSession}" in URL and "${flagSession}" via ` +
+          `${options?.spawn ? "--spawn" : "--session"}. Provide only one.`,
+      );
+      process.exit(1);
+    }
+    const sessionName = urlSession ?? flagSession;
+    if (!sessionName) {
+      console.error(
+        `connect to ssh peer "${authorityUrl}" needs a session name. ` +
+          `Append \`/<name>\` to the URL or pass \`--session <name>\`.`,
+      );
+      process.exit(1);
+    }
+
+    // Look up by authority (userHost + port), NOT by label — the caller
+    // typed the URL, and it may not literally equal any stored sshUrl
+    // string even when they identify the same peer (implicit port 22 vs
+    // `:22`, for example).
+    const wantAuth = parseSshUrl(authorityUrl);
+    const hosts = await loadAllKnownHosts(store);
+    const match = hosts.find((h) => {
+      if (!isSshHost(h)) return false;
+      try {
+        const auth = parseSshUrl(h.sshUrl);
+        return auth.userHost === wantAuth.userHost && auth.port === wantAuth.port;
+      } catch {
+        return false;
+      }
+    });
+    if (!match) {
+      console.error(
+        `No known ssh peer matching ${authorityUrl}. ` +
+          `Run \`pty-relay add ${authorityUrl}\` to register it.`,
+      );
+      process.exit(1);
+    }
+    const code = await attachSshRemoteSession(match.sshUrl!, sessionName);
+    process.exit(code ?? 0);
+  }
+
   if (!looksLikeTokenUrl(tokenUrlOrLabel)) {
     const { store, passphrase } = await openSecretStore(options?.configDir, {
       interactive: true,

--- a/src/relay/transport-ssh.ts
+++ b/src/relay/transport-ssh.ts
@@ -118,6 +118,50 @@ export function looksLikeSshUrl(s: string): boolean {
 }
 
 /**
+ * Split an `ssh://[user@]host[:port][/session]` string into its
+ * authority-only URL (the part `parseSshUrl` accepts) and, if
+ * present, the trailing session segment.
+ *
+ * `parseSshUrl` deliberately rejects paths — sshUrl entries in
+ * known-hosts are authority-only by contract. But CLI callers hand
+ * us the URL in "full address" form with the session name in the
+ * path (mirroring how the `pty` TUI stitches attach-remote URLs
+ * together), so connect / peek / send / etc. need to peel the
+ * session off before doing the known-hosts lookup.
+ *
+ * Empty trailing slash is allowed and treated as "no session":
+ * `ssh://host/` → { authorityUrl: "ssh://host", session: undefined }
+ *
+ * A path with more than one segment is an error — we don't know what
+ * to do with `ssh://host/foo/bar` and would rather fail loudly than
+ * silently discard `bar`.
+ */
+export function splitSshUrlAndSession(input: string): {
+  authorityUrl: string;
+  session?: string;
+} {
+  if (typeof input !== "string" || !input.startsWith("ssh://")) {
+    throw new Error(`not an ssh URL: ${input}`);
+  }
+  const rest = input.slice("ssh://".length);
+  const slashIdx = rest.indexOf("/");
+  if (slashIdx === -1) {
+    return { authorityUrl: input };
+  }
+  const authority = rest.slice(0, slashIdx);
+  const path = rest.slice(slashIdx + 1);
+  if (path.length === 0) {
+    return { authorityUrl: `ssh://${authority}` };
+  }
+  if (path.includes("/")) {
+    throw new Error(
+      `ssh URL path must be a single session name (got: ${input})`,
+    );
+  }
+  return { authorityUrl: `ssh://${authority}`, session: path };
+}
+
+/**
  * Default options applied to every `ssh` invocation. Centralized so a
  * future caller can override via a per-call options arg without each
  * subcommand redefining them.

--- a/test/transport-ssh.test.ts
+++ b/test/transport-ssh.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   parseSshUrl,
   looksLikeSshUrl,
+  splitSshUrlAndSession,
 } from "../src/relay/transport-ssh.ts";
 
 describe("parseSshUrl", () => {
@@ -106,5 +107,62 @@ describe("looksLikeSshUrl", () => {
   it("rejects non-string input gracefully (defensive against bad CLI args)", () => {
     expect(looksLikeSshUrl(null as unknown as string)).toBe(false);
     expect(looksLikeSshUrl(undefined as unknown as string)).toBe(false);
+  });
+});
+
+describe("splitSshUrlAndSession", () => {
+  it("returns authority-only URL unchanged when no path", () => {
+    expect(splitSshUrlAndSession("ssh://host")).toEqual({
+      authorityUrl: "ssh://host",
+    });
+    expect(splitSshUrlAndSession("ssh://me@host:2222")).toEqual({
+      authorityUrl: "ssh://me@host:2222",
+    });
+  });
+
+  it("splits the trailing session name off the path", () => {
+    expect(splitSshUrlAndSession("ssh://host/work")).toEqual({
+      authorityUrl: "ssh://host",
+      session: "work",
+    });
+    expect(splitSshUrlAndSession("ssh://me@host:2222/edit-42")).toEqual({
+      authorityUrl: "ssh://me@host:2222",
+      session: "edit-42",
+    });
+  });
+
+  it("treats a trailing empty path as 'no session'", () => {
+    // Matches how parseSshUrl already allows `ssh://host/` — cleanly
+    // ignored, no error.
+    expect(splitSshUrlAndSession("ssh://host/")).toEqual({
+      authorityUrl: "ssh://host",
+    });
+  });
+
+  it("rejects paths with more than one segment", () => {
+    // Silently dropping `bar` would surprise callers. Loud fail is
+    // safer than a wrong dispatch.
+    expect(() => splitSshUrlAndSession("ssh://host/foo/bar")).toThrow(
+      /single session name/,
+    );
+  });
+
+  it("rejects non-ssh URLs", () => {
+    expect(() => splitSshUrlAndSession("https://host/x")).toThrow(
+      /not an ssh URL/,
+    );
+    expect(() => splitSshUrlAndSession("label-only")).toThrow(/not an ssh URL/);
+  });
+
+  it("returns an authority URL that parseSshUrl accepts", () => {
+    // Round-trip: split → parse the authority. Guards against
+    // reintroducing a path when we reconstruct the URL.
+    const { authorityUrl } = splitSshUrlAndSession(
+      "ssh://me@host:2222/work",
+    );
+    expect(parseSshUrl(authorityUrl)).toEqual({
+      userHost: "me@host",
+      port: 2222,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fix B (belt) mirroring pty's Fix A (suspenders) for Nathan's `pty-relay connect ssh://... exits 1 with 'No known host'` bug. The pty TUI now short-circuits to `connect <label> --session <name>` when the peer is ssh://, but pty-relay should also accept the full URL directly — so a hand-typed URL or any future caller works the same on either side of the seam.

## Before → After

`connect ssh://user@host/session` before:
- `looksLikeTokenUrl(\"ssh://...\")` → `false` → label branch
- `resolveHost(\"ssh://user@host/session\")` → \`find(h => h.label === X)\` → miss → \"No known host\"
- Even if it resolved, the ssh branch required `--session`; the URL-embedded session was invisible

Dispatch order after this PR:
1. `ssh://…` — new branch
2. `http(s)://…` — self-hosted token URL (unchanged)
3. anything else — known-hosts label lookup (unchanged)

The new branch:
- Splits the URL into `authorityUrl` + optional trailing `session` via a small companion helper `splitSshUrlAndSession(input)`.
- Errors if BOTH the URL path AND `--session`/`--spawn` carry a session (ambiguous — mirrors how token URLs handle path/hash conflicts).
- Looks up the ssh peer by the `(userHost, port)` tuple — not by literal string match — so `ssh://me@host` and `ssh://me@host:22` resolve to the same known-host entry, and future normalization changes don't break the lookup.
- Hands `(matched.sshUrl, sessionName)` to `attachSshRemoteSession` — the same codepath as `connect <label> --session <name>` today.

`parseSshUrl` still rejects any URL with a path (sshUrl entries in known-hosts are authority-only by contract); the new splitter is what CLI callers use to peel the session off before doing that lookup.

## Not in scope

The brief lists `peek` / `send` / `tag` / `events` / `kill` as consistency asks — they accept `<host> <session>` today and could grow the same URL-with-path shape. Marked as \"operator's call\" in the brief, so leaving for a follow-up to keep this PR focused on the reported bug.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/transport-ssh.test.ts` → 25/25 (6 new for splitSshUrlAndSession, round-trip through parseSshUrl included)
- [x] `npx vitest run --config integration/vitest.config.ts integration/peers-file.test.ts` → 14/14 (4 new: URL with session, URL without session, URL + --session ambiguity, unregistered authority)
- [ ] Reviewer to confirm the by-authority lookup reads cleanly and the ambiguity error surfaces well in practice