### PR TITLE
feat(cli): pty-relay peers subcommand + peers/hosts vocab standardization

### DIFF
--- a/integration/peers-file.test.ts
+++ b/integration/peers-file.test.ts
@@ -119,6 +119,52 @@ function readCallLog(): string {
   return fs.readFileSync(path.join(fakeSshDir, "calls.log"), "utf-8");
 }
 
+describe("pty-relay peers subcommand", () => {
+  it("empty install prints a helpful hint", () => {
+    // Nuke any peers file the previous suite wrote.
+    try { fs.rmSync(peersFile); } catch {}
+    const result = runCli(["peers", "--config-dir", configDir]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No known peers");
+    expect(result.stdout).toContain("pty-relay add");
+  });
+
+  it("--json emits {label, url, source, kind} rows for peers-file entries", () => {
+    fs.writeFileSync(peersFile, "ssh://you@web7  json-web\n");
+    const result = runCli(["peers", "--config-dir", configDir, "--json"]);
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout) as Array<{
+      label: string;
+      url: string;
+      source: string;
+      kind: string;
+    }>;
+    expect(parsed).toEqual([
+      {
+        label: "json-web",
+        url: "ssh://you@web7",
+        source: "peers-file",
+        kind: "ssh",
+      },
+    ]);
+  });
+
+  it("plain output aligns URL column and doesn't fan out (no ssh calls)", () => {
+    fs.writeFileSync(peersFile, "ssh://a@short  a\nssh://b@longer-label  b-longer\n");
+    clearCallLog();
+    const result = runCli(["peers", "--config-dir", configDir]);
+    expect(result.status).toBe(0);
+    const lines = result.stdout.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    // Both URL starts should land at the same column (padding lines
+    // up to the widest label).
+    const urlCol = (l: string) => l.indexOf("ssh://");
+    expect(urlCol(lines[0])).toBe(urlCol(lines[1]));
+    // No session fanout — the fake ssh's calls.log must be empty.
+    expect(readCallLog()).toBe("");
+  });
+});
+
 describe("peers file — declarative provisioning", () => {
   it("ls discovers a peer dropped into the peers file (zero commands run)", () => {
     fs.writeFileSync(peersFile, "ssh://nathan@web1.example.com  prod-web\n");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,9 @@ function usage(): void {
 Commands:
   init                      Initialize secret storage (first-time setup)
   reset                     Delete all saved credentials (start over)
-  ls                        List known hosts and their sessions
+  peers                     List known peers (terse — no session fanout)
+  peers --json              Emit JSON with source + kind per peer
+  ls                        List known peers and their sessions (fans out)
   ls --filter-tag k=v       Filter sessions by tag (repeatable, all must match)
   peek <host> <session>                        Print the current screen of a remote session
   peek --plain | --full                        Plain text (no ANSI) / full scrollback
@@ -55,10 +57,10 @@ Commands:
   events <host>                                Follow events from a remote daemon (Ctrl+C to stop)
   events --session <name> <host>               Filter to a single session
   events --json <host>                         Emit JSONL for scripting
-  rename <old> <new>        Rename a saved known-host entry
-  forget <host-label>       Remove a saved host
+  rename <old> <new>        Rename a saved peer
+  forget <peer-label>       Remove a saved peer
   add ssh://[user@]host[:port] [--label <name>]
-                            Add an ssh-reachable peer to known-hosts.
+                            Add an ssh-reachable peer.
                             Probes with ssh BatchMode=yes + pty
                             --version before saving so unreachable
                             peers don't get recorded.
@@ -354,6 +356,15 @@ async function main(): Promise<void> {
       break;
     }
 
+    case "peers": {
+      // Terse peer-only listing — no session fanout, no network probes.
+      // Complements `ls`, which is the fanout-and-probe view.
+      const configDir = getFlag("--config-dir") ?? undefined;
+      const { peers } = await import("./commands/peers.ts");
+      await peers(configDir, hasFlag("--json"), { passphraseFile });
+      break;
+    }
+
     case "peek": {
       // Flags can appear anywhere; positionals are the last two non-flag
       // tokens. Collect --wait (repeatable) and -t/--timeout while scanning.
@@ -607,8 +618,8 @@ async function main(): Promise<void> {
     case "forget": {
       const label = args[1];
       if (!label) {
-        console.error("Usage: pty-relay forget <host-label>");
-        console.error("  Run 'pty-relay ls' to see host labels.");
+        console.error("Usage: pty-relay forget <peer-label>");
+        console.error("  Run 'pty-relay peers' to see peer labels.");
         process.exit(1);
       }
       const configDir = getFlag("--config-dir") ?? undefined;
@@ -621,8 +632,8 @@ async function main(): Promise<void> {
       const before = await loadKnownHosts(store);
       const count = before.filter((h) => h.label === label).length;
       if (count === 0) {
-        console.error(`No known host with label "${label}".`);
-        console.error("  Run 'pty-relay ls' to see host labels.");
+        console.error(`No known peer with label "${label}".`);
+        console.error("  Run 'pty-relay peers' to see peer labels.");
         process.exit(1);
       }
       await removeKnownHost(label, store);
@@ -999,6 +1010,7 @@ Options:
 const CLIENT_PASSTHROUGH_COMMANDS = new Set([
   "ls",
   "list",
+  "peers",
   "connect",
   "peek",
   "send",
@@ -1086,11 +1098,12 @@ Subcommands:
   join --label <name>             Label this device advertises on the account
   join --totp-code <code>         Non-interactive TOTP code
 
-  ls                              List known hosts and their sessions
-  connect <host-or-url>           Attach to a remote pty session
-  peek <host> <session>           Print a remote session's screen
-  send <host> <session> "text"    Send input to a remote session
-  tag <host> <session>            Show / set tags on a remote session
+  peers                           List known peers (terse)
+  ls                              List known peers and their sessions
+  connect <peer-or-url>           Attach to a remote pty session
+  peek <peer> <session>           Print a remote session's screen
+  send <peer> <session> "text"    Send input to a remote session
+  tag <peer> <session>            Show / set tags on a remote session
   events <host>                   Follow events from a remote daemon
   rename <old> <new>              Rename a saved known-host entry
   forget <host-label>             Remove a saved host

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -53,7 +53,7 @@ export async function ls(
     if (json) {
       console.log(JSON.stringify([]));
     } else {
-      console.log("No known hosts.");
+      console.log("No known peers.");
       console.log("Connect to a daemon first:");
       console.log("  pty-relay connect <token-url>");
     }

--- a/src/commands/peers.ts
+++ b/src/commands/peers.ts
@@ -1,0 +1,83 @@
+import { ready } from "../crypto/index.ts";
+import {
+  loadAllKnownHostsWithSource,
+  isPublicHost,
+  isSshHost,
+  type PeerEntry,
+} from "../relay/known-hosts.ts";
+import { openSecretStore } from "../storage/bootstrap.ts";
+import { log } from "../log.ts";
+
+/**
+ * `pty-relay peers [--json]` — terse peer listing.
+ *
+ * Complement to `ls`: `ls` fans out over every known peer to fetch
+ * their session lists (heavy, network-bound). `peers` answers "what
+ * peers do I know" from local reads only — encrypted store + peers
+ * file — with no network probes and no session fanout.
+ *
+ * The JSON shape includes provenance (`source`) so callers can tell
+ * imperative-vs-declarative rows apart, and transport `kind` so they
+ * can distinguish self-hosted / public / ssh peers without pattern-
+ * matching the URL.
+ */
+export interface PeerRow {
+  label: string;
+  url: string;
+  source: "known-hosts" | "peers-file";
+  kind: "self" | "public" | "ssh";
+}
+
+export async function peers(
+  configDir?: string,
+  json = false,
+  opts?: { passphraseFile?: string },
+): Promise<void> {
+  await ready();
+  log("cli", "peers start", { configDir, json });
+
+  const { store } = await openSecretStore(configDir, {
+    interactive: true,
+    passphraseFile: opts?.passphraseFile,
+  });
+  const entries = await loadAllKnownHostsWithSource(store);
+  const rows = entries.map(toPeerRow);
+
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log("No known peers.");
+    console.log("Add one:");
+    console.log("  pty-relay add ssh://[user@]host[:port]");
+    console.log("  pty-relay connect <token-url>");
+    console.log("Or drop a peers file at ~/.config/pty-relay/peers.");
+    return;
+  }
+
+  // One row per peer, `<label>  <url>`. Padding to the longest label
+  // keeps the URL column aligned without pulling in a table renderer.
+  const maxLabel = rows.reduce((n, r) => Math.max(n, r.label.length), 0);
+  for (const row of rows) {
+    const pad = " ".repeat(maxLabel - row.label.length + 2);
+    console.log(`${row.label}${pad}${row.url}`);
+  }
+}
+
+function toPeerRow(entry: PeerEntry): PeerRow {
+  const h = entry.host;
+  if (isSshHost(h)) {
+    return { label: h.label, url: h.sshUrl, source: entry.source, kind: "ssh" };
+  }
+  if (isPublicHost(h)) {
+    return {
+      label: h.label,
+      url: `${h.relayUrl}@${h.publicKey.slice(0, 8)}`,
+      source: entry.source,
+      kind: "public",
+    };
+  }
+  return { label: h.label, url: h.url!, source: entry.source, kind: "self" };
+}

--- a/src/relay/host-resolve.ts
+++ b/src/relay/host-resolve.ts
@@ -69,7 +69,7 @@ export async function resolveHost(
   if (!host) {
     log("hosts", "resolve miss", { label, known: hosts.length });
     throw new Error(
-      `No known host "${label}". Run \`pty-relay ls\` to list hosts.`
+      `No known peer "${label}". Run \`pty-relay peers\` to list peers.`
     );
   }
 

--- a/src/relay/known-hosts.ts
+++ b/src/relay/known-hosts.ts
@@ -325,15 +325,47 @@ async function persist(hosts: KnownHost[], store: SecretStore): Promise<void> {
 export async function loadAllKnownHosts(
   store: SecretStore,
 ): Promise<KnownHost[]> {
+  const tagged = await loadAllKnownHostsWithSource(store);
+  return tagged.map((t) => t.host);
+}
+
+/** Peer origin as surfaced by `pty-relay peers --json`. `known-hosts`
+ *  means the encrypted store (`connect` / `add` / `server signin`
+ *  wrote it); `peers-file` means a declarative row in the peers file
+ *  that survived the merge in `loadAllKnownHostsWithSource`. */
+export type PeerSource = "known-hosts" | "peers-file";
+
+export interface PeerEntry {
+  host: KnownHost;
+  source: PeerSource;
+}
+
+/**
+ * Same merge behavior as `loadAllKnownHosts`, but tags each returned
+ * entry with its provenance so callers that need to distinguish
+ * imperative-vs-declarative rows (e.g. `pty-relay peers --json`)
+ * don't have to do the merge themselves.
+ *
+ * Encrypted-store entries WIN on label collisions — the operator
+ * explicitly saved them via `connect` / `add` / `server signin`, so
+ * an accidental peers-file line with the same label shouldn't shadow
+ * them.
+ */
+export async function loadAllKnownHostsWithSource(
+  store: SecretStore,
+): Promise<PeerEntry[]> {
   // Imported lazily so the encrypted-store-only path doesn't need to
   // pull in the peers-file module for write operations.
   const { loadPeersFile } = await import("./peers-file.ts");
   const stored = await loadKnownHosts(store);
   const fromFile = loadPeersFile();
-  if (fromFile.length === 0) return stored;
+  const merged: PeerEntry[] = stored.map((host) => ({
+    host,
+    source: "known-hosts" as const,
+  }));
+  if (fromFile.length === 0) return merged;
 
   const storedLabels = new Set(stored.map((h) => h.label));
-  const merged: KnownHost[] = [...stored];
   let shadowed = 0;
   let renamed = 0;
 
@@ -351,13 +383,16 @@ export async function loadAllKnownHosts(
     // entries that happen to share a label (rare but possible when
     // explicit labels are used).
     let label = candidate.label;
-    if (merged.some((h) => h.label === label)) {
+    if (merged.some((h) => h.host.label === label)) {
       let n = 2;
-      while (merged.some((h) => h.label === `${candidate.label}-${n}`)) n++;
+      while (merged.some((h) => h.host.label === `${candidate.label}-${n}`)) n++;
       label = `${candidate.label}-${n}`;
       renamed++;
     }
-    merged.push({ ...candidate, label });
+    merged.push({
+      host: { ...candidate, label },
+      source: "peers-file",
+    });
   }
 
   log("hosts", "load merged", {

--- a/test/peers-command.test.ts
+++ b/test/peers-command.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SecretName, SecretStore } from "../src/storage/secret-store.ts";
+import {
+  loadAllKnownHostsWithSource,
+  saveKnownHost,
+  savePublicKnownHost,
+  saveSshKnownHost,
+} from "../src/relay/known-hosts.ts";
+
+/**
+ * Tests for loadAllKnownHostsWithSource — the tagged-tuple variant of
+ * loadAllKnownHosts. This is what `pty-relay peers --json` uses to
+ * populate the `source` column, so its provenance tagging (and the
+ * store-wins collision behavior) has to stay correct even as the
+ * peers-file merge evolves.
+ *
+ * We drive the peers file via PTY_RELAY_PEERS_FILE so we don't touch
+ * the developer's real XDG_CONFIG_HOME while tests run.
+ */
+
+class MemStore implements SecretStore {
+  readonly backend = "passphrase" as const;
+  private data = new Map<SecretName, Uint8Array>();
+  async load(n: SecretName) {
+    return this.data.get(n) ?? null;
+  }
+  async save(n: SecretName, p: Uint8Array) {
+    this.data.set(n, p);
+  }
+  async delete(n: SecretName) {
+    this.data.delete(n);
+  }
+}
+
+let tmpDir: string;
+let peersFile: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "peers-cmd-"));
+  peersFile = path.join(tmpDir, "peers");
+  env = { ...process.env };
+  delete process.env.XDG_CONFIG_HOME;
+  process.env.PTY_RELAY_PEERS_FILE = peersFile;
+});
+
+afterEach(() => {
+  process.env = env;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadAllKnownHostsWithSource", () => {
+  it("tags store-only entries as source: known-hosts", async () => {
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "web1", sshUrl: "ssh://me@web1" }, store);
+    // No peers file on disk.
+    const entries = await loadAllKnownHostsWithSource(store);
+    expect(entries).toEqual([
+      {
+        host: { label: "web1", sshUrl: "ssh://me@web1" },
+        source: "known-hosts",
+      },
+    ]);
+  });
+
+  it("tags peers-file entries as source: peers-file", async () => {
+    const store = new MemStore();
+    fs.writeFileSync(peersFile, "ssh://me@web1  prod-web\n");
+    const entries = await loadAllKnownHostsWithSource(store);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe("peers-file");
+    expect(entries[0].host.label).toBe("prod-web");
+  });
+
+  it("returns both sources with correct tags when mixed", async () => {
+    const store = new MemStore();
+    await saveKnownHost("local", "http://localhost:8099#pk.s", store);
+    fs.writeFileSync(peersFile, "ssh://me@web1  prod-web\n");
+    const entries = await loadAllKnownHostsWithSource(store);
+    const bySource = Object.fromEntries(entries.map((e) => [e.host.label, e.source]));
+    expect(bySource).toEqual({
+      local: "known-hosts",
+      "prod-web": "peers-file",
+    });
+  });
+
+  it("preserves store-wins semantics: file line with same label is dropped, not tagged", async () => {
+    // If the operator has both an explicit store entry and a peers-file
+    // line for the same label, the file row is skipped entirely — so
+    // there's only one entry, tagged known-hosts. Otherwise `peers`
+    // would double-list under different provenances, which is worse
+    // than the silent-winner behavior.
+    const store = new MemStore();
+    await saveSshKnownHost({ label: "web1", sshUrl: "ssh://me@web1" }, store);
+    fs.writeFileSync(peersFile, "ssh://you@web1  web1\n");
+    const entries = await loadAllKnownHostsWithSource(store);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe("known-hosts");
+    expect(entries[0].host.sshUrl).toBe("ssh://me@web1");
+  });
+
+  it("keeps entry counts right when many public / self / ssh mix", async () => {
+    const store = new MemStore();
+    await saveKnownHost("home", "http://home:8099#pk.s", store);
+    await savePublicKnownHost(
+      { label: "cloud", relayUrl: "http://relay", publicKey: "pk" },
+      store,
+    );
+    await saveSshKnownHost({ label: "shell", sshUrl: "ssh://shell" }, store);
+    fs.writeFileSync(peersFile, "ssh://me@web1  prod-web\n");
+    const entries = await loadAllKnownHostsWithSource(store);
+    expect(entries).toHaveLength(4);
+    const known = entries.filter((e) => e.source === "known-hosts");
+    const file = entries.filter((e) => e.source === "peers-file");
+    expect(known).toHaveLength(3);
+    expect(file).toHaveLength(1);
+  });
+
+  it("returns empty when neither store nor file has entries", async () => {
+    const store = new MemStore();
+    const entries = await loadAllKnownHostsWithSource(store);
+    expect(entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Nathan asked for pty-relay's user-facing text to lead with **peers** — the config file is already called `peers`, but `ls` / `rename` / `forget` / `--help` all still said `hosts`. This aligns the surfaces and adds a fast peer-only listing complement to `ls`.

## New command: `pty-relay peers [--json]`

Terse listing — no session fanout, no network probes. Answers \"what peers do I know\" from local reads only. Complements `ls` (which is the fanout-and-probe view — heavier, network-bound).

- **Plain output**: one `<label>  <url>` line per peer, URL column padded to align with the longest label.
- **`--json` output**: `{label, url, source, kind}` per row.
  - `source`: `\"known-hosts\"` | `\"peers-file\"` — imperatively saved via `connect`/`add`/`server signin` vs declaratively provisioned via the peers file.
  - `kind`: `\"self\"` | `\"public\"` | `\"ssh\"` — transport, so callers don't have to pattern-match the URL to tell them apart.

Populated via a new `loadAllKnownHostsWithSource(store)` in `known-hosts.ts`. `loadAllKnownHosts` is now a thin wrapper that strips the source tag — existing callers unchanged.

## Vocab renames (user-facing only)

- `--help` blurbs: `ls` / `rename` / `forget` / `add` descriptions.
- `pty-relay ls` empty output: `\"No known hosts.\"` → `\"No known peers.\"`
- `resolveHost` miss error: `\"No known host X\"` → `\"No known peer X\"` with the ls-hint replaced by a peers-hint.
- `pty-relay forget` usage + not-found error mention peers, not hosts.
- `pty-relay client` subcommand help mirrors the top-level rename.

## What's NOT changed

- **`ls` verb** stays — well-established; not strictly a rename of `peers` (ls fans out sessions, peers does not). Help text cross-references the two.
- **`add` / `rename` / `forget` verbs** stay — the noun in their help updates, verbs are fine.
- **Internal types** (`KnownHost` / `known-hosts.ts` / `loadKnownHosts`) — operator never sees these. Renaming would be pure churn; the brief explicitly leans skip.
- **The peers file itself** + its parser — already using the right term.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` → 774/774 (up from 768; 6 new for `loadAllKnownHostsWithSource`)
- [x] `npx vitest run --config integration/vitest.config.ts integration/peers-file.test.ts` → 13/13 (3 new: empty-install hint, `--json` shape, plain-output column alignment with a confirming \"no ssh calls\" assertion — peers is local-only)
- [ ] Reviewer to eyeball the help text for missed \"hosts\" strings, especially in `client --help` / `server --help`