### PR TITLE
fix: 3 non-doc github.com/myobie URLs → compoundingtech

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/myobie/pty-relay"
+    "url": "https://github.com/compoundingtech/pty-relay"
   },
   "engines": {
     "node": ">=22"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,8 +123,8 @@ Options:
                              reconciles against server output as it
                              arrives; auto-disabled in alternate-screen
                              mode (vim, htop). OFF by default. Beta —
-                             feedback welcome at github.com/myobie/
-                             pty-relay/issues/12.
+                             feedback welcome at
+                             github.com/compoundingtech/pty-relay/issues/12.
   --skip-osc8-confirm       Skip the click-confirmation prompt for
                              OSC 8 hyperlinks in the web terminal —
                              clicks open the URL directly in a new

--- a/src/relay/transport-ssh.ts
+++ b/src/relay/transport-ssh.ts
@@ -532,7 +532,7 @@ function translateSshError(err: unknown, sshUrl: string): Error {
   if (stderr.includes("command not found") || stderr.includes("not found")) {
     return new Error(
       `${sshUrl}: pty is not on the remote PATH. Install pty there ` +
-        `(see https://github.com/myobie/pty) and re-try.`,
+        `(see https://github.com/compoundingtech/pty) and re-try.`,
     );
   }
   if (stderr.includes("could not resolve hostname")) {


### PR DESCRIPTION
package.json repository.url, src/cli.ts feedback URL, transport-ssh.ts hint → compoundingtech. git grep github.com/myobie now zero; @myobie npm scope untouched; 789 tests pass.