### PR TITLE
feat: pty-relay --version → <semver>+<short-sha>

### DIFF
--- a/integration/e2e.test.ts
+++ b/integration/e2e.test.ts
@@ -749,7 +749,7 @@ describe("version command", () => {
       { encoding: "utf-8", timeout: 5000 }
     );
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/^pty-relay \d+\.\d+\.\d+/);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+(\+[0-9a-f]+)?$/);
   });
 
   it("'version' subcommand also works", () => {
@@ -759,7 +759,7 @@ describe("version command", () => {
       { encoding: "utf-8", timeout: 5000 }
     );
     expect(result.status).toBe(0);
-    expect(result.stdout).toMatch(/^pty-relay \d+\.\d+\.\d+/);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+(\+[0-9a-f]+)?$/);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -738,9 +738,25 @@ async function main(): Promise<void> {
       try {
         const pkgPath = path.resolve(import.meta.dirname, "../package.json");
         const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-        console.log(`pty-relay ${pkg.version}`);
+        // Standard CLI format: <semver>+<short-sha>. The sha is appended
+        // only when run from a source checkout — resolve git relative to
+        // this file (not the user's cwd) so it reflects the pty-relay
+        // repo. A published npm install isn't a git repo, so git fails
+        // and the plain semver prints.
+        let sha = "";
+        try {
+          const { execFileSync } = await import("node:child_process");
+          sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+            cwd: import.meta.dirname,
+            stdio: ["ignore", "pipe", "ignore"],
+            timeout: 1000,
+          })
+            .toString()
+            .trim();
+        } catch {}
+        console.log(sha ? `${pkg.version}+${sha}` : pkg.version);
       } catch {
-        console.log("pty-relay (version unknown)");
+        console.log("unknown");
       }
       process.exit(0);
       break;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -112,21 +112,22 @@ describe("CLI", () => {
     expect(stdout).toContain("reset");
   });
 
-  it("--version prints the package version and exits 0", () => {
+  it("--version prints <semver>+<sha> (no name prefix) and exits 0", () => {
     const { stdout, exitCode } = runCli(["--version"]);
-    expect(stdout).toMatch(/pty-relay \d+\.\d+\.\d+/);
+    // Standard format: bare semver, optionally +<short-sha> from a checkout.
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+(\+[0-9a-f]+)?$/);
     expect(exitCode).toBe(0);
   });
 
   it("-v is an alias for --version", () => {
     const { stdout, exitCode } = runCli(["-v"]);
-    expect(stdout).toMatch(/pty-relay \d+\.\d+\.\d+/);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+(\+[0-9a-f]+)?$/);
     expect(exitCode).toBe(0);
   });
 
   it("version subcommand works the same as --version", () => {
     const { stdout, exitCode } = runCli(["version"]);
-    expect(stdout).toMatch(/pty-relay \d+\.\d+\.\d+/);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+(\+[0-9a-f]+)?$/);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
0.1.0+<sha> in a checkout, bare 0.1.0 on npm install. Prefix-less to match convoy + pty (house standard). sha via git rev-parse (import.meta.dirname), 1s timeout, graceful omit. 789 unit + 2 integration green.